### PR TITLE
Run release job on tag push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
Run the release job on tag push - I think this was dropped in a rebase
earlier.