### PR TITLE
Fix issue with root command inheritance

### DIFF
--- a/foxglove/cmd/export.go
+++ b/foxglove/cmd/export.go
@@ -43,7 +43,7 @@ func executeExport(baseURL, clientID, deviceID, start, end, outputFormat, topicL
 	return nil
 }
 
-func newExportCommand(baseURL, clientID string) (*cobra.Command, error) {
+func newExportCommand(baseURL, clientID *string) (*cobra.Command, error) {
 	var deviceID string
 	var start string
 	var end string
@@ -54,8 +54,8 @@ func newExportCommand(baseURL, clientID string) (*cobra.Command, error) {
 		Short: "Export a data selection from foxglove data platform",
 		Run: func(cmd *cobra.Command, args []string) {
 			err := executeExport(
-				baseURL,
-				clientID,
+				*baseURL,
+				*clientID,
 				deviceID,
 				start,
 				end,

--- a/foxglove/cmd/import.go
+++ b/foxglove/cmd/import.go
@@ -19,19 +19,20 @@ func executeImport(baseURL, clientID, deviceID, filename, token string) error {
 	return nil
 }
 
-func newImportCommand(baseURL, clientID string) (*cobra.Command, error) {
+func newImportCommand(baseURL, clientID *string) (*cobra.Command, error) {
 	var deviceID string
 	var filename string
 	importCmd := &cobra.Command{
 		Use:   "import",
 		Short: "Import a data file to the foxglove data platform",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := executeImport(baseURL, clientID, deviceID, filename, viper.GetString("bearer_token"))
+			err := executeImport(*baseURL, *clientID, deviceID, filename, viper.GetString("bearer_token"))
 			if err != nil {
 				fmt.Printf("Import failed: %s\n", err)
 			}
 		},
 	}
+	importCmd.InheritedFlags()
 	importCmd.PersistentFlags().StringVarP(&deviceID, "device-id", "", "", "device ID")
 	importCmd.PersistentFlags().StringVarP(&filename, "filename", "", "", "filename")
 	err := importCmd.MarkPersistentFlagRequired("device-id")

--- a/foxglove/cmd/login.go
+++ b/foxglove/cmd/login.go
@@ -25,16 +25,17 @@ func executeLogin(baseURL, clientID string) error {
 	return nil
 }
 
-func newLoginCommand(baseURL, clientID string) *cobra.Command {
+func newLoginCommand(baseURL, clientID *string) *cobra.Command {
 	loginCmd := &cobra.Command{
 		Use:   "login",
 		Short: "Log in to the foxglove data platform",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := executeLogin(baseURL, clientID)
+			err := executeLogin(*baseURL, *clientID)
 			if err != nil {
 				fmt.Printf("Login failed: %s\n", err)
 			}
 		},
 	}
+	loginCmd.InheritedFlags()
 	return loginCmd
 }

--- a/foxglove/cmd/login_test.go
+++ b/foxglove/cmd/login_test.go
@@ -14,16 +14,16 @@ import (
 func TestLoginCommand(t *testing.T) {
 	ctx := context.Background()
 	svc, port := svc.NewMockServer(ctx)
-	err := initConfig("./test-config.yaml")
+	configfile := "./test-config.yaml"
+	err := initConfig(&configfile)
 	assert.Nil(t, err)
 	err = executeLogin(fmt.Sprintf("http://localhost:%d", port), "client-id")
 	assert.Nil(t, err)
 	assert.NotEmpty(t, svc.BearerTokens)
 	m := make(map[string]string)
-	filename := "./test-config.yaml"
-	f, err := os.Open(filename)
+	f, err := os.Open(configfile)
 	assert.Nil(t, err)
-	defer os.Remove(filename)
+	defer os.Remove(configfile)
 	defer f.Close()
 	err = yaml.NewDecoder(f).Decode(&m)
 	assert.Nil(t, err)


### PR DESCRIPTION
In attempting to avoid using global variables in the way cobra
encourages you to, we were failing to pick up root command flags when
supplied. This prevented me from using the CLI tool against a local
console deployment.