### PR TITLE
Use tags for version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,8 @@ jobs:
       - name: Build
         run: |
           cd foxglove
-          go build -o "$BINARY_NAME" -v
+          make build
+          mv foxglove "$BINARY_NAME"
           cd -
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/foxglove/Makefile
+++ b/foxglove/Makefile
@@ -4,12 +4,12 @@ lint:
 test:
 	go test ./... -cover
 
-gitcommit: $(eval GIT_COMMIT=$(shell git log -1 --pretty=format:"%H"))
-gitcommit:
-	@echo GIT_COMMIT=$(GIT_COMMIT)
+version: $(eval VERSION=$(shell git describe --tags))
+version:
+	@echo VERSION=$(VERSION)
 
-build: gitcommit
-	go build -ldflags "-X main.GitCommit=$(GIT_COMMIT)"
+build: version
+	go build -ldflags "-X main.Version=$(VERSION)"
 
-install: gitcommit
-	go install -ldflags "-X main.GitCommit=$(GIT_COMMIT)"
+install: version
+	go install -ldflags "-X main.Version=$(VERSION)"

--- a/foxglove/main.go
+++ b/foxglove/main.go
@@ -4,9 +4,9 @@ import "github.com/foxglove/foxglove-cli/foxglove/cmd"
 
 // build variables
 var (
-	GitCommit string
+	Version string
 )
 
 func main() {
-	cmd.Execute(GitCommit)
+	cmd.Execute(Version)
 }


### PR DESCRIPTION
Switches the version tag to the output of git describe --tags:

For an untagged release, this gives us the most recent tag and the
commit shorthash:

./foxglove version
v0.0.1b-2-gcd6aafc

For a tagged release, it gives us just the tag.