### PR TITLE
Fix deadlock in stdout redirection test

### DIFF
--- a/foxglove/cmd/export.go
+++ b/foxglove/cmd/export.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -23,7 +24,7 @@ func stdoutRedirected() bool {
 	return true
 }
 
-func executeExport(baseURL, clientID, deviceID, start, end, outputFormat, topicList, bearerToken string) error {
+func executeExport(w io.Writer, baseURL, clientID, deviceID, start, end, outputFormat, topicList, bearerToken string) error {
 	ctx := context.Background()
 	client := svc.NewRemoteFoxgloveClient(
 		baseURL,
@@ -36,7 +37,7 @@ func executeExport(baseURL, clientID, deviceID, start, end, outputFormat, topicL
 	if !stdoutRedirected() {
 		return fmt.Errorf("Binary output may screw up your terminal. Please redirect to a pipe or file.\n")
 	}
-	err := svc.Export(ctx, os.Stdout, client, deviceID, start, end, topics, outputFormat)
+	err := svc.Export(ctx, w, client, deviceID, start, end, topics, outputFormat)
 	if err != nil {
 		return fmt.Errorf("Export failed: %s", err)
 	}
@@ -54,6 +55,7 @@ func newExportCommand(baseURL, clientID *string) (*cobra.Command, error) {
 		Short: "Export a data selection from foxglove data platform",
 		Run: func(cmd *cobra.Command, args []string) {
 			err := executeExport(
+				os.Stdout,
 				*baseURL,
 				*clientID,
 				deviceID,

--- a/foxglove/svc/client.go
+++ b/foxglove/svc/client.go
@@ -137,12 +137,7 @@ func (c *foxgloveClient) Stream(r StreamRequest) (io.ReadCloser, error) {
 		bytes, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("unexpected %d from stream service: %s", resp.StatusCode, string(bytes))
 	}
-
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read stream: %w", err)
-	}
-	return io.NopCloser(bytes.NewReader(data)), nil
+	return resp.Body, nil
 }
 
 // Upload uploads the contents of a reader for a provided filenamem and device.

--- a/foxglove/svc/lib.go
+++ b/foxglove/svc/lib.go
@@ -47,6 +47,7 @@ func Export(
 		return fmt.Errorf("streaming request failure: %w", err)
 	}
 	defer rc.Close()
+
 	_, err = io.Copy(w, rc)
 	if err != nil {
 		return fmt.Errorf("copy failure: %w", err)


### PR DESCRIPTION
This uncomments a test that was previously commented out locally and
mistakenly committed. The reason the test was commented out was a
deadlock in one of the test utilities, which I believe was caused by
stdout getting redirected too late, after an earlier reference was taken
by the writer. This commit does a bit of rearranging to avoid the
deadlock.