### PR TITLE
Send user agent in all http requests

### DIFF
--- a/foxglove/cmd/export.go
+++ b/foxglove/cmd/export.go
@@ -24,12 +24,13 @@ func stdoutRedirected() bool {
 	return true
 }
 
-func executeExport(w io.Writer, baseURL, clientID, deviceID, start, end, outputFormat, topicList, bearerToken string) error {
+func executeExport(w io.Writer, baseURL, clientID, deviceID, start, end, outputFormat, topicList, bearerToken, userAgent string) error {
 	ctx := context.Background()
 	client := svc.NewRemoteFoxgloveClient(
 		baseURL,
 		clientID,
 		bearerToken,
+		userAgent,
 	)
 	topics := strings.FieldsFunc(topicList, func(c rune) bool {
 		return c == ','
@@ -44,7 +45,7 @@ func executeExport(w io.Writer, baseURL, clientID, deviceID, start, end, outputF
 	return nil
 }
 
-func newExportCommand(baseURL, clientID *string) (*cobra.Command, error) {
+func newExportCommand(params *baseParams) (*cobra.Command, error) {
 	var deviceID string
 	var start string
 	var end string
@@ -56,14 +57,15 @@ func newExportCommand(baseURL, clientID *string) (*cobra.Command, error) {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := executeExport(
 				os.Stdout,
-				*baseURL,
-				*clientID,
+				*params.baseURL,
+				*params.clientID,
 				deviceID,
 				start,
 				end,
 				outputFormat,
 				topicList,
 				viper.GetString("bearer_token"),
+				params.userAgent,
 			)
 			if err != nil {
 				fmt.Printf("Export failed: %s\n", err)

--- a/foxglove/cmd/export_test.go
+++ b/foxglove/cmd/export_test.go
@@ -51,6 +51,7 @@ func TestExportCommand(t *testing.T) {
 			"mcap",
 			"/diagnostics",
 			"",
+			"user-agent",
 		)
 		assert.Equal(t, "Export failed: streaming request failure: forbidden", err.Error())
 	})
@@ -60,7 +61,7 @@ func TestExportCommand(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			_, port := svc.NewMockServer(ctx)
-			client := svc.NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", port), "client-id", "")
+			client := svc.NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", port), "client-id", "", "test-app")
 			token, err := client.SignIn("client-id")
 			assert.Nil(t, err)
 			err = executeExport(
@@ -73,6 +74,7 @@ func TestExportCommand(t *testing.T) {
 				"mcap",
 				"/diagnostics",
 				token,
+				"user-agent",
 			)
 			assert.Nil(t, err)
 		})
@@ -84,7 +86,7 @@ func TestExportCommand(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 		_, port := svc.NewMockServer(ctx)
-		client := svc.NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", port), "client-id", "")
+		client := svc.NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", port), "client-id", "", "test-app")
 		token, err := client.SignIn("client-id")
 		assert.Nil(t, err)
 		baseurl := fmt.Sprintf("http://localhost:%d", port)
@@ -96,6 +98,7 @@ func TestExportCommand(t *testing.T) {
 			deviceID,
 			"../svc/testdata/gps.bag",
 			token,
+			"user-agent",
 		)
 		assert.Nil(t, err)
 		err = withStdoutRedirected(buf, func() {
@@ -109,6 +112,7 @@ func TestExportCommand(t *testing.T) {
 				"bag1",
 				"/diagnostics",
 				token,
+				"user-agent",
 			)
 			assert.Nil(t, err)
 		})

--- a/foxglove/cmd/import.go
+++ b/foxglove/cmd/import.go
@@ -9,9 +9,9 @@ import (
 	"github.com/spf13/viper"
 )
 
-func executeImport(baseURL, clientID, deviceID, filename, token string) error {
+func executeImport(baseURL, clientID, deviceID, filename, token, userAgent string) error {
 	ctx := context.Background()
-	client := svc.NewRemoteFoxgloveClient(baseURL, clientID, token)
+	client := svc.NewRemoteFoxgloveClient(baseURL, clientID, token, userAgent)
 	err := svc.Import(ctx, client, deviceID, filename)
 	if err != nil {
 		return err
@@ -19,14 +19,14 @@ func executeImport(baseURL, clientID, deviceID, filename, token string) error {
 	return nil
 }
 
-func newImportCommand(baseURL, clientID *string) (*cobra.Command, error) {
+func newImportCommand(params *baseParams) (*cobra.Command, error) {
 	var deviceID string
 	var filename string
 	importCmd := &cobra.Command{
 		Use:   "import",
 		Short: "Import a data file to the foxglove data platform",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := executeImport(*baseURL, *clientID, deviceID, filename, viper.GetString("bearer_token"))
+			err := executeImport(*params.baseURL, *params.clientID, deviceID, filename, viper.GetString("bearer_token"), params.userAgent)
 			if err != nil {
 				fmt.Printf("Import failed: %s\n", err)
 			}

--- a/foxglove/cmd/login.go
+++ b/foxglove/cmd/login.go
@@ -10,9 +10,9 @@ import (
 	"github.com/spf13/viper"
 )
 
-func executeLogin(baseURL, clientID string) error {
+func executeLogin(baseURL, clientID, userAgent string) error {
 	ctx := context.Background()
-	client := svc.NewRemoteFoxgloveClient(baseURL, clientID, viper.GetString("bearer_token"))
+	client := svc.NewRemoteFoxgloveClient(baseURL, clientID, viper.GetString("bearer_token"), userAgent)
 	bearerToken, err := svc.Login(ctx, client)
 	if err != nil {
 		return err
@@ -25,12 +25,12 @@ func executeLogin(baseURL, clientID string) error {
 	return nil
 }
 
-func newLoginCommand(baseURL, clientID *string) *cobra.Command {
+func newLoginCommand(params *baseParams) *cobra.Command {
 	loginCmd := &cobra.Command{
 		Use:   "login",
 		Short: "Log in to the foxglove data platform",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := executeLogin(*baseURL, *clientID)
+			err := executeLogin(*params.baseURL, *params.clientID, params.userAgent)
 			if err != nil {
 				fmt.Printf("Login failed: %s\n", err)
 			}

--- a/foxglove/cmd/login_test.go
+++ b/foxglove/cmd/login_test.go
@@ -17,7 +17,7 @@ func TestLoginCommand(t *testing.T) {
 	configfile := "./test-config.yaml"
 	err := initConfig(&configfile)
 	assert.Nil(t, err)
-	err = executeLogin(fmt.Sprintf("http://localhost:%d", port), "client-id")
+	err = executeLogin(fmt.Sprintf("http://localhost:%d", port), "client-id", "test-app")
 	assert.Nil(t, err)
 	assert.NotEmpty(t, svc.BearerTokens)
 	m := make(map[string]string)

--- a/foxglove/cmd/root.go
+++ b/foxglove/cmd/root.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	foxgloveClientID = "d51173be08ed4cf7a734aed9ac30afd0"
+	appname          = "foxglove-cli"
 )
 
 func configfile() (string, error) {
@@ -20,6 +21,13 @@ func configfile() (string, error) {
 		return "", err
 	}
 	return path.Join(home, ".foxgloverc"), nil
+}
+
+type baseParams struct {
+	clientID  *string
+	cfgFile   *string
+	baseURL   *string
+	userAgent string
 }
 
 func Execute(version string) {
@@ -36,6 +44,14 @@ func Execute(version string) {
 	rootCmd.PersistentFlags().StringVarP(&clientID, "client-id", "", foxgloveClientID, "foxglove client ID")
 	rootCmd.PersistentFlags().StringVarP(&baseURL, "baseurl", "", "https://api.foxglove.dev", "console API server")
 
+	useragent := fmt.Sprintf("%s/%s", appname, version)
+	params := &baseParams{
+		userAgent: useragent,
+		cfgFile:   &cfgFile,
+		baseURL:   &baseURL,
+		clientID:  &clientID,
+	}
+
 	var err error
 	if cfgFile == "" {
 		cfgFile, err = configfile()
@@ -49,17 +65,17 @@ func Execute(version string) {
 		fmt.Println(err)
 		return
 	}
-	importCmd, err := newImportCommand(&baseURL, &clientID)
+	importCmd, err := newImportCommand(params)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
-	exportCmd, err := newExportCommand(&baseURL, &clientID)
+	exportCmd, err := newExportCommand(params)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
-	loginCmd := newLoginCommand(&baseURL, &clientID)
+	loginCmd := newLoginCommand(params)
 	rootCmd.AddCommand(importCmd)
 	rootCmd.AddCommand(exportCmd)
 	rootCmd.AddCommand(loginCmd)

--- a/foxglove/svc/lib_test.go
+++ b/foxglove/svc/lib_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func login(ctx context.Context, sv *MockFoxgloveServer) (string, error) {
-	client := NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", sv.port), "abc", "")
+	client := NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", sv.port), "abc", "", "test-app")
 	return Login(ctx, client)
 }
 
@@ -21,7 +21,7 @@ func TestImport(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 		_, port := NewMockServer(ctx)
-		client := NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", port), "abc", "")
+		client := NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", port), "abc", "", "test-app")
 		err := Import(ctx, client, "test-device", "./testdata/gps.bag")
 		assert.ErrorIs(t, err, ErrForbidden)
 	})
@@ -31,7 +31,7 @@ func TestImport(t *testing.T) {
 		srv, port := NewMockServer(ctx)
 		token, err := login(ctx, srv)
 		assert.Nil(t, err)
-		client := NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", port), "abc", token)
+		client := NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", port), "abc", token, "test-app")
 		err = Import(ctx, client, "test-device", "./testdata/gps.bag")
 		assert.Nil(t, err)
 		assert.Equal(t, 5324051, len(srv.Uploads["device_id=test-device/gps.bag"]))
@@ -44,7 +44,7 @@ func TestExport(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 		_, port := NewMockServer(ctx)
-		client := NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", port), "abc", "")
+		client := NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", port), "abc", "", "test-app")
 		buf := &bytes.Buffer{}
 		err := Export(ctx, buf, client, "test-device", "2020-01-01T00:00:00Z", "2021-01-01T00:00:00Z", []string{}, "mcap")
 		assert.ErrorIs(t, err, ErrForbidden)
@@ -55,7 +55,7 @@ func TestExport(t *testing.T) {
 		sv, port := NewMockServer(ctx)
 		token, err := login(ctx, sv)
 		assert.Nil(t, err)
-		client := NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", port), "abc", token)
+		client := NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", port), "abc", token, "test-app")
 		buf := &bytes.Buffer{}
 		err = Export(ctx, buf, client, "test-device", "2020-01-01T00:00:00Z", "2021-01-01T00:00:00Z", []string{}, "mcap")
 		assert.Nil(t, err)
@@ -67,7 +67,7 @@ func TestExport(t *testing.T) {
 		sv, port := NewMockServer(ctx)
 		token, err := login(ctx, sv)
 		assert.Nil(t, err)
-		client := NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", port), "abc", token)
+		client := NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", port), "abc", token, "test-app")
 		buf := &bytes.Buffer{}
 		err = Import(ctx, client, "test-device", "./testdata/gps.bag")
 		assert.Nil(t, err)
@@ -83,7 +83,7 @@ func TestLogin(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 		_, port := NewMockServer(ctx)
-		client := NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", port), "abc", "")
+		client := NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", port), "abc", "", "test-app")
 		bearerToken, err := Login(ctx, client)
 		assert.Nil(t, err)
 		assert.NotEmpty(t, bearerToken)
@@ -92,7 +92,7 @@ func TestLogin(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, 600*time.Millisecond)
 		defer cancel()
 		_, port := NewMockServer(ctx)
-		client := NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", port), "abc", "")
+		client := NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", port), "abc", "", "test-app")
 		bearerToken, err := Login(ctx, client)
 		assert.ErrorIs(t, context.Canceled, err)
 		assert.Empty(t, bearerToken)


### PR DESCRIPTION
Sends a user agent string formatted "foxglove-cli/<version>" as the user
agent header in all HTTP requests to the platform.