### PR TITLE
Split subcommands under 'auth' and 'data'

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,19 @@ See `foxglove -h` for complete usage documentation.
 
 1. Authenticate to Foxglove
 ```
-foxglove login
+foxglove auth login
 ```
 
 2. Import data
 
 ```
-foxglove import --filename ~/data/bags/gps.bag --device-id dev_flm75pLkfzUBX2DH
+foxglove data import --filename ~/data/bags/gps.bag --device-id dev_flm75pLkfzUBX2DH
 ```
 
 3. Query data
 
 ```
-$ foxglove export --device-id dev_flm75pLkfzUBX2DH --start 2001-01-01T00:00:00Z --end 2022-01-01T00:00:00Z --output-format bag1 --topics /gps/fix,/gps/fix_velocity > output.bag
+$ foxglove data export --device-id dev_flm75pLkfzUBX2DH --start 2001-01-01T00:00:00Z --end 2022-01-01T00:00:00Z --output-format bag1 --topics /gps/fix,/gps/fix_velocity > output.bag
 
 $ rosbag reindex output.bag
 

--- a/foxglove/cmd/root.go
+++ b/foxglove/cmd/root.go
@@ -34,10 +34,19 @@ func Execute(version string) {
 	if version == "" {
 		version = "dev"
 	}
-	var rootCmd = &cobra.Command{
+	rootCmd := &cobra.Command{
 		Use:   "foxglove",
 		Short: "Command line client for the Foxglove data platform",
 	}
+	authCmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Manage authentication",
+	}
+	dataCmd := &cobra.Command{
+		Use:   "data",
+		Short: "Data access and management",
+	}
+
 	var baseURL, clientID, cfgFile string
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "", "", "config file (default is $HOME/.foxglove.yaml)")
@@ -76,10 +85,9 @@ func Execute(version string) {
 		return
 	}
 	loginCmd := newLoginCommand(params)
-	rootCmd.AddCommand(importCmd)
-	rootCmd.AddCommand(exportCmd)
-	rootCmd.AddCommand(loginCmd)
-	rootCmd.AddCommand(newVersionCommand(version))
+	rootCmd.AddCommand(authCmd, dataCmd, newVersionCommand(version))
+	authCmd.AddCommand(loginCmd)
+	dataCmd.AddCommand(importCmd, exportCmd)
 	cobra.CheckErr(rootCmd.Execute())
 }
 


### PR DESCRIPTION
Splits the top-level subcommands under auth and data divisions. The
usage is now,

    foxglove auth login ...
    foxglove data import ...
    foxglove data export ...