### PR TITLE
Switch to positional import filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ foxglove auth login
 2. Import data
 
 ```
-foxglove data import --filename ~/data/bags/gps.bag --device-id dev_flm75pLkfzUBX2DH
+foxglove data import ~/data/bags/gps.bag --device-id dev_flm75pLkfzUBX2DH
 ```
 
 3. Query data

--- a/foxglove/cmd/import.go
+++ b/foxglove/cmd/import.go
@@ -21,11 +21,12 @@ func executeImport(baseURL, clientID, deviceID, filename, token, userAgent strin
 
 func newImportCommand(params *baseParams) (*cobra.Command, error) {
 	var deviceID string
-	var filename string
 	importCmd := &cobra.Command{
-		Use:   "import",
+		Use:   "import [FILE]",
 		Short: "Import a data file to the foxglove data platform",
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			filename := args[0] // guaranteed length 1 due to Args setting above
 			err := executeImport(*params.baseURL, *params.clientID, deviceID, filename, viper.GetString("bearer_token"), params.userAgent)
 			if err != nil {
 				fmt.Printf("Import failed: %s\n", err)
@@ -34,12 +35,7 @@ func newImportCommand(params *baseParams) (*cobra.Command, error) {
 	}
 	importCmd.InheritedFlags()
 	importCmd.PersistentFlags().StringVarP(&deviceID, "device-id", "", "", "device ID")
-	importCmd.PersistentFlags().StringVarP(&filename, "filename", "", "", "filename")
 	err := importCmd.MarkPersistentFlagRequired("device-id")
-	if err != nil {
-		return nil, err
-	}
-	err = importCmd.MarkPersistentFlagRequired("filename")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Switch the import command's filename argument from a named parameter to
a positional arg. If exactly one argument is not supplied, the command
fails with a helpful message.