### PR TITLE
Add "devices" command with "list" subcommand

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+foxglove/testdata/gps.bag filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -41,13 +41,25 @@ See `foxglove -h` for complete usage documentation.
 foxglove auth login
 ```
 
-2. Import data
+1. Import data
 
 ```
 foxglove data import ~/data/bags/gps.bag --device-id dev_flm75pLkfzUBX2DH
 ```
 
-3. Query data
+1. List available devices for querying
+
+```
+foxglove devices list
+|          ID          |        NAME        |      CREATED AT      |      UPDATED AT      |
+|----------------------|--------------------|----------------------|----------------------|
+| dev_mHH1Cp4gPybCPR8y | Adrian's Robot     | 2021-10-28T17:20:55Z | 2021-10-28T17:20:55Z |
+| dev_WEJUVEOVApoIpe1M | GPS                | 2021-11-01T17:38:55Z | 2021-11-01T17:38:55Z |
+| dev_flm75pLkfzUBX2DH | updog              | 2021-11-25T02:22:45Z | 2021-11-25T02:22:45Z |
+| dev_lwjzOMxryMmP3yXg | nuScenes-v1.0-mini | 2021-12-09T21:45:51Z | 2021-12-09T21:45:51Z |
+```
+
+1. Query imported data
 
 ```
 $ foxglove data export --device-id dev_flm75pLkfzUBX2DH --start 2001-01-01T00:00:00Z --end 2022-01-01T00:00:00Z --output-format bag1 --topics /gps/fix,/gps/fix_velocity > output.bag

--- a/foxglove/cmd/devices.go
+++ b/foxglove/cmd/devices.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/foxglove/foxglove-cli/foxglove/svc"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func renderDevicesJSON(w io.Writer, devices []svc.DeviceResponse) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "    ")
+	return encoder.Encode(devices)
+}
+
+func renderDevicesCSV(w io.Writer, devices []svc.DeviceResponse) error {
+	writer := csv.NewWriter(w)
+	err := writer.Write([]string{
+		"id",
+		"name",
+		"createdAt",
+		"updatedAt",
+	})
+	if err != nil {
+		return err
+	}
+	for _, device := range devices {
+		err := writer.Write([]string{
+			device.ID,
+			device.Name,
+			device.CreatedAt.Format(time.RFC3339),
+			device.UpdatedAt.Format(time.RFC3339),
+		})
+		if err != nil {
+			return err
+		}
+	}
+	writer.Flush()
+	return writer.Error()
+}
+
+func renderDevicesTable(w io.Writer, devices []svc.DeviceResponse) {
+	table := tablewriter.NewWriter(w)
+	table.SetHeader([]string{
+		"ID",
+		"Name",
+		"Created At",
+		"Updated At",
+	})
+	table.SetBorders(tablewriter.Border{
+		Left:   true,
+		Top:    false,
+		Right:  true,
+		Bottom: false,
+	})
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("|")
+	data := [][]string{}
+	for _, device := range devices {
+		data = append(data, []string{
+			device.ID,
+			device.Name,
+			device.CreatedAt.Format(time.RFC3339),
+			device.UpdatedAt.Format(time.RFC3339),
+		})
+	}
+	table.AppendBulk(data)
+	table.Render()
+}
+
+func listDevices(
+	w io.Writer,
+	baseURL,
+	clientID,
+	format, token, userAgent string,
+) error {
+	client := svc.NewRemoteFoxgloveClient(baseURL, clientID, token, userAgent)
+	devices, err := client.Devices()
+	if err != nil {
+		return err
+	}
+	switch format {
+	case "table":
+		renderDevicesTable(w, devices)
+	case "json":
+		err := renderDevicesJSON(w, devices)
+		if err != nil {
+			return err
+		}
+	case "csv":
+		err := renderDevicesCSV(w, devices)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported format %s", format)
+	}
+	return nil
+}
+
+func newListDevicesCommand(params *baseParams) *cobra.Command {
+	var format string
+	deviceListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List devices registered to your organization",
+		Run: func(cmd *cobra.Command, args []string) {
+			err := listDevices(
+				os.Stdout,
+				*params.baseURL,
+				*params.clientID,
+				format,
+				viper.GetString("bearer_token"),
+				params.userAgent,
+			)
+			if err != nil {
+				fmt.Printf("Failed to list devices: %s\n", err)
+			}
+		},
+	}
+	deviceListCmd.InheritedFlags()
+	deviceListCmd.PersistentFlags().StringVarP(
+		&format,
+		"format",
+		"",
+		"table",
+		"render output in specified format (table, json, csv)",
+	)
+	return deviceListCmd
+}

--- a/foxglove/cmd/devices_test.go
+++ b/foxglove/cmd/devices_test.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/foxglove/foxglove-cli/foxglove/svc"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListDevices(t *testing.T) {
+	ctx := context.Background()
+	for _, format := range []string{"table", "json", "csv"} {
+		t.Run(fmt.Sprintf(
+			"format %s returns forbidden if not authenticated", format),
+			func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+				defer cancel()
+				sv, err := svc.NewMockServer(ctx)
+				assert.Nil(t, err)
+				buf := &bytes.Buffer{}
+				err = listDevices(
+					buf,
+					sv.BaseURL(),
+					"abc",
+					format,
+					"",
+					"user-agent",
+				)
+				assert.ErrorIs(t, err, svc.ErrForbidden)
+			})
+		t.Run(fmt.Sprintf(
+			"format %s authenticated requests succeed without error", format),
+			func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+				defer cancel()
+				sv, err := svc.NewMockServer(ctx)
+				assert.Nil(t, err)
+				buf := &bytes.Buffer{}
+				client := svc.NewRemoteFoxgloveClient(sv.BaseURL(), "client-id", "", "test-app")
+				token, err := client.SignIn("client-id")
+				assert.Nil(t, err)
+				err = listDevices(
+					buf,
+					sv.BaseURL(),
+					"client-id",
+					format,
+					token,
+					"user-agent",
+				)
+				assert.Nil(t, err)
+			})
+	}
+	t.Run("authenticated csv request results in parseable data", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+		sv, err := svc.NewMockServer(ctx)
+		assert.Nil(t, err)
+		client := svc.NewRemoteFoxgloveClient(sv.BaseURL(), "client-id", "", "test-app")
+		token, err := client.SignIn("client-id")
+		assert.Nil(t, err)
+		err = listDevices(
+			buf,
+			sv.BaseURL(),
+			"client-id",
+			"csv",
+			token,
+			"user-agent",
+		)
+		assert.Nil(t, err)
+		reader := csv.NewReader(buf)
+		devices, err := reader.ReadAll()
+		assert.Nil(t, err)
+		assert.Equal(t, 2, len(devices)) // header record + one data record
+	})
+	t.Run("authenticated json request results in parseable data", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+		sv, err := svc.NewMockServer(ctx)
+		assert.Nil(t, err)
+		client := svc.NewRemoteFoxgloveClient(sv.BaseURL(), "client-id", "", "test-app")
+		token, err := client.SignIn("client-id")
+		assert.Nil(t, err)
+		err = listDevices(
+			buf,
+			sv.BaseURL(),
+			"client-id",
+			"json",
+			token,
+			"user-agent",
+		)
+		assert.Nil(t, err)
+		devices := []svc.DeviceResponse{}
+		err = json.NewDecoder(buf).Decode(&devices)
+		assert.Nil(t, err)
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(devices))
+	})
+}

--- a/foxglove/cmd/export.go
+++ b/foxglove/cmd/export.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/foxglove/foxglove-cli/foxglove/svc"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -24,8 +23,11 @@ func stdoutRedirected() bool {
 	return true
 }
 
-func executeExport(w io.Writer, baseURL, clientID, deviceID, start, end, outputFormat, topicList, bearerToken, userAgent string) error {
-	ctx := context.Background()
+func executeExport(
+	ctx context.Context,
+	w io.Writer,
+	baseURL, clientID, deviceID, start, end, outputFormat, topicList, bearerToken, userAgent string,
+) error {
 	client := svc.NewRemoteFoxgloveClient(
 		baseURL,
 		clientID,
@@ -56,6 +58,7 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 		Short: "Export a data selection from foxglove data platform",
 		Run: func(cmd *cobra.Command, args []string) {
 			err := executeExport(
+				cmd.Context(),
 				os.Stdout,
 				*params.baseURL,
 				*params.clientID,
@@ -64,7 +67,7 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 				end,
 				outputFormat,
 				topicList,
-				viper.GetString("bearer_token"),
+				params.token,
 				params.userAgent,
 			)
 			if err != nil {

--- a/foxglove/cmd/export_test.go
+++ b/foxglove/cmd/export_test.go
@@ -43,6 +43,7 @@ func TestExportCommand(t *testing.T) {
 		sv, err := svc.NewMockServer(ctx)
 		assert.Nil(t, err)
 		err = executeExport(
+			context.TODO(),
 			buf,
 			sv.BaseURL(),
 			"abc",
@@ -67,6 +68,7 @@ func TestExportCommand(t *testing.T) {
 			token, err := client.SignIn("client-id")
 			assert.Nil(t, err)
 			err = executeExport(
+				context.TODO(),
 				buf,
 				sv.BaseURL(),
 				"abc",
@@ -105,6 +107,7 @@ func TestExportCommand(t *testing.T) {
 		assert.Nil(t, err)
 		err = withStdoutRedirected(buf, func() {
 			err := executeExport(
+				context.TODO(),
 				buf,
 				sv.BaseURL(),
 				clientID,

--- a/foxglove/cmd/import.go
+++ b/foxglove/cmd/import.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/foxglove/foxglove-cli/foxglove/svc"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 func executeImport(baseURL, clientID, deviceID, filename, token, userAgent string) error {
@@ -27,7 +26,7 @@ func newImportCommand(params *baseParams) (*cobra.Command, error) {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			filename := args[0] // guaranteed length 1 due to Args setting above
-			err := executeImport(*params.baseURL, *params.clientID, deviceID, filename, viper.GetString("bearer_token"), params.userAgent)
+			err := executeImport(*params.baseURL, *params.clientID, deviceID, filename, params.token, params.userAgent)
 			if err != nil {
 				fmt.Printf("Import failed: %s\n", err)
 			}

--- a/foxglove/cmd/login.go
+++ b/foxglove/cmd/login.go
@@ -12,7 +12,7 @@ import (
 
 func executeLogin(baseURL, clientID, userAgent string) error {
 	ctx := context.Background()
-	client := svc.NewRemoteFoxgloveClient(baseURL, clientID, viper.GetString("bearer_token"), userAgent)
+	client := svc.NewRemoteFoxgloveClient(baseURL, clientID, "", userAgent)
 	bearerToken, err := svc.Login(ctx, client)
 	if err != nil {
 		return err

--- a/foxglove/cmd/root.go
+++ b/foxglove/cmd/root.go
@@ -28,6 +28,7 @@ type baseParams struct {
 	cfgFile   *string
 	baseURL   *string
 	userAgent string
+	token     string
 }
 
 func Execute(version string) {
@@ -46,6 +47,10 @@ func Execute(version string) {
 		Use:   "data",
 		Short: "Data access and management",
 	}
+	devicesCmd := &cobra.Command{
+		Use:   "devices",
+		Short: "List and manage devices",
+	}
 
 	var baseURL, clientID, cfgFile string
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
@@ -59,6 +64,7 @@ func Execute(version string) {
 		cfgFile:   &cfgFile,
 		baseURL:   &baseURL,
 		clientID:  &clientID,
+		token:     viper.GetString("bearer_token"),
 	}
 
 	var err error
@@ -85,9 +91,10 @@ func Execute(version string) {
 		return
 	}
 	loginCmd := newLoginCommand(params)
-	rootCmd.AddCommand(authCmd, dataCmd, newVersionCommand(version))
+	rootCmd.AddCommand(authCmd, dataCmd, newVersionCommand(version), devicesCmd)
 	authCmd.AddCommand(loginCmd)
 	dataCmd.AddCommand(importCmd, exportCmd)
+	devicesCmd.AddCommand(newListDevicesCommand(params))
 	cobra.CheckErr(rootCmd.Execute())
 }
 

--- a/foxglove/go.mod
+++ b/foxglove/go.mod
@@ -4,10 +4,12 @@ go 1.17
 
 require (
 	github.com/gorilla/mux v1.8.0
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/schollz/progressbar/v3 v3.8.3
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.9.0
 	github.com/stretchr/testify v1.7.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -32,6 +34,5 @@ require (
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/ini.v1 v1.66.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/foxglove/go.sum
+++ b/foxglove/go.sum
@@ -219,6 +219,7 @@ github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcME
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -240,6 +241,8 @@ github.com/mitchellh/mapstructure v1.4.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
@@ -474,7 +477,6 @@ golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0 h1:xrCZDmdtoloIiooiA9q0OQb9r8HejIHYoHGhGCe1pGg=
 golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 h1:TyHqChC80pFkXWraUUf6RuB5IqFdQieMLwwCJokV2pc=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -488,7 +490,6 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
@@ -687,7 +688,6 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/ini.v1 v1.63.2 h1:tGK/CyBg7SMzb60vP1M03vNZ3VDu3wGQJwn7Sxi9r3c=
 gopkg.in/ini.v1 v1.63.2/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.66.0 h1:tYFFjdYXTsNBxJhYBABRbTuaKkX6UBzOvbYwhEcaZJQ=
 gopkg.in/ini.v1 v1.66.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=


### PR DESCRIPTION
Adds a new top-level "devices" command, under which we can place device
management and interogation subcommands. The first subcommand
implemented in this patch is "list".

The "foxglove devices list" call supports an optional parameter,
"format", which can be used to indicate the desired output format for
the list of devices. Supported formats are "table", "json", and "csv".
The default format is "table".