### PR TITLE
Send CLI errors to stderr

### DIFF
--- a/foxglove/cmd/coverage.go
+++ b/foxglove/cmd/coverage.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/foxglove/foxglove-cli/foxglove/console"
@@ -32,8 +31,7 @@ func newListCoverageCommand(params *baseParams) *cobra.Command {
 				format,
 			)
 			if err != nil {
-				fmt.Printf("Failed to list coverage: %s\n", err)
-				os.Exit(1)
+				fatalf("Failed to list coverage: %s\n", err)
 			}
 		},
 	}

--- a/foxglove/cmd/devices.go
+++ b/foxglove/cmd/devices.go
@@ -59,8 +59,7 @@ func newAddDeviceCommand(params *baseParams) *cobra.Command {
 				SerialNumber: serialNumber,
 			})
 			if err != nil {
-				fmt.Printf("Failed to create device: %s\n", err)
-				os.Exit(1)
+				fatalf("Failed to create device: %s\n", err)
 			}
 			fmt.Printf("Device created: %s\n", resp.ID)
 		},

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -95,8 +95,7 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 				format,
 			)
 			if err != nil {
-				fmt.Printf("Failed to list events: %s\n", err)
-				os.Exit(1)
+				fatalf("Failed to list events: %s\n", err)
 			}
 		},
 	}

--- a/foxglove/cmd/export.go
+++ b/foxglove/cmd/export.go
@@ -234,6 +234,7 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 		Use:   "export",
 		Short: "Export a data selection from foxglove data platform",
 		Run: func(cmd *cobra.Command, args []string) {
+			defer os.Stdout.Close()
 			err := executeExport(
 				cmd.Context(),
 				os.Stdout,
@@ -248,9 +249,8 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 				params.userAgent,
 			)
 			if err != nil {
-				fmt.Printf("Export failed: %s\n", err)
+				fatalf("Export failed: %s\n", err)
 			}
-			os.Stdout.Close()
 		},
 	}
 	exportCmd.PersistentFlags().StringVarP(&deviceID, "device-id", "", "", "device ID")

--- a/foxglove/cmd/import.go
+++ b/foxglove/cmd/import.go
@@ -36,7 +36,7 @@ func newImportCommand(params *baseParams, commandName string) (*cobra.Command, e
 				params.userAgent,
 			)
 			if err != nil {
-				fmt.Printf("Import failed: %s\n", err)
+				fatalf("Import failed: %s\n", err)
 			}
 		},
 	}

--- a/foxglove/cmd/login.go
+++ b/foxglove/cmd/login.go
@@ -32,7 +32,7 @@ func newLoginCommand(params *baseParams) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := executeLogin(*params.baseURL, *params.clientID, params.userAgent)
 			if err != nil {
-				fmt.Printf("Login failed: %s\n", err)
+				fatalf("Login failed: %s\n", err)
 			}
 		},
 	}

--- a/foxglove/cmd/utils.go
+++ b/foxglove/cmd/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/foxglove/foxglove-cli/foxglove/console"
 	"github.com/olekukonko/tablewriter"
@@ -82,4 +83,9 @@ func renderCSV[RecordType console.Record](w io.Writer, records []RecordType) err
 	}
 	writer.Flush()
 	return writer.Error()
+}
+
+func fatalf(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format, args...)
+	os.Exit(1)
 }


### PR DESCRIPTION
Prior to this commit, errors for some commands were going to stdout
instead of stderr, resulting in confusing error-valued outputs when
redirecting stdout for export.