### PR TITLE
Document coverage + add params

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ $ foxglove beta events list
 
 For adding events, see `foxglove beta events add -h`.
 
+#### Coverage
+The tool supports listing coverage ranges:
+
+```
+(main) $ foxglove data coverage list --start '2016-01-01T00:00:00Z' --end '2018-02-01T00:00:00Z'
+|      DEVICE ID       |             START              |              END               |
+|----------------------|--------------------------------|--------------------------------|
+| dev_flm75pLkfzUBX2DH | 2017-03-22T02:26:20.103843113Z | 2017-03-22T02:26:27.884601618Z |
+| dev_JOgi4YiCRgaoszKw | 2016-11-18T23:46:10.29593596Z  | 2016-11-18T23:51:25.906093435Z |
+| dev_mHH1Cp4gPybCPR8y | 2017-03-22T02:26:20.103843113Z | 2017-03-22T02:26:27.884601618Z |
+```
+
 #### Querying data
 ```
 $ foxglove data export --device-id dev_drpLqjBZYUzus3gv --start 2001-01-01T00:00:00Z --end 2022-01-01T00:00:00Z --output-format mcap0 --topics /gps/fix,/gps/fix_velocity > output.mcap

--- a/foxglove/cmd/coverage.go
+++ b/foxglove/cmd/coverage.go
@@ -12,6 +12,8 @@ func newListCoverageCommand(params *baseParams) *cobra.Command {
 	var format string
 	var start string
 	var end string
+	var tolerance int
+	var deviceID string
 	coverageListCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List coverage ranges",
@@ -24,8 +26,10 @@ func newListCoverageCommand(params *baseParams) *cobra.Command {
 			err := renderList(
 				os.Stdout,
 				&console.CoverageRequest{
-					Start: start,
-					End:   end,
+					Start:     start,
+					End:       end,
+					DeviceID:  deviceID,
+					Tolerance: tolerance,
 				},
 				client.Coverage,
 				format,
@@ -38,6 +42,8 @@ func newListCoverageCommand(params *baseParams) *cobra.Command {
 	coverageListCmd.InheritedFlags()
 	coverageListCmd.PersistentFlags().StringVarP(&start, "start", "", "", "start of coverage time range")
 	coverageListCmd.PersistentFlags().StringVarP(&end, "end", "", "", "end of coverage time range")
+	coverageListCmd.PersistentFlags().StringVarP(&deviceID, "device-id", "", "", "restrict output to specific device")
+	coverageListCmd.PersistentFlags().IntVarP(&tolerance, "tolerance", "", 0, "number of seconds of separation required for ranges to be considered distinct")
 	coverageListCmd.PersistentFlags().StringVarP(
 		&format,
 		"format",

--- a/foxglove/console/api.go
+++ b/foxglove/console/api.go
@@ -184,9 +184,12 @@ func (r EventsResponse) Headers() []string {
 }
 
 type CoverageRequest struct {
-	Start string `json:"start" form:"start,omitempty"`
-	End   string `json:"end" form:"end,omitempty"`
+	Start     string `json:"start" form:"start,omitempty"`
+	End       string `json:"end" form:"end,omitempty"`
+	Tolerance int    `json:"tolerance" form:"tolerance,omitempty"`
+	DeviceID  string `json:"deviceId" form:"deviceId,omitempty"`
 }
+
 type CoverageResponse struct {
 	DeviceID string `json:"deviceId"`
 	Start    string `json:"start"`


### PR DESCRIPTION
Documents support for coverage listing and adds tolerance and device ID parameters.