### PR TITLE
Prevent spawned windows in macOS test runs

### DIFF
--- a/foxglove/cmd/login.go
+++ b/foxglove/cmd/login.go
@@ -10,10 +10,10 @@ import (
 	"github.com/spf13/viper"
 )
 
-func executeLogin(baseURL, clientID, userAgent string) error {
+func executeLogin(baseURL, clientID, userAgent string, authDelegate console.AuthDelegate) error {
 	ctx := context.Background()
 	client := console.NewRemoteFoxgloveClient(baseURL, clientID, "", userAgent)
-	bearerToken, err := console.Login(ctx, client)
+	bearerToken, err := console.Login(ctx, client, authDelegate)
 	if err != nil {
 		return err
 	}
@@ -30,7 +30,7 @@ func newLoginCommand(params *baseParams) *cobra.Command {
 		Use:   "login",
 		Short: "Log in to the foxglove data platform",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := executeLogin(*params.baseURL, *params.clientID, params.userAgent)
+			err := executeLogin(*params.baseURL, *params.clientID, params.userAgent, &console.PlatformAuthDelegate{})
 			if err != nil {
 				fatalf("Login failed: %s\n", err)
 			}

--- a/foxglove/cmd/login_test.go
+++ b/foxglove/cmd/login_test.go
@@ -17,7 +17,7 @@ func TestLoginCommand(t *testing.T) {
 	configfile := "./test-config.yaml"
 	err = initConfig(&configfile)
 	assert.Nil(t, err)
-	err = executeLogin(sv.BaseURL(), "client-id", "test-app")
+	err = executeLogin(sv.BaseURL(), "client-id", "test-app", &console.MockAuthDelegate{})
 	assert.Nil(t, err)
 	assert.NotEmpty(t, sv.BearerTokens)
 	m := make(map[string]string)

--- a/foxglove/console/lib_test.go
+++ b/foxglove/console/lib_test.go
@@ -12,7 +12,7 @@ import (
 
 func login(ctx context.Context, sv *MockFoxgloveServer) (string, error) {
 	client := NewRemoteFoxgloveClient(fmt.Sprintf("http://localhost:%d", sv.port), "abc", "", "test-app")
-	return Login(ctx, client)
+	return Login(ctx, client, &MockAuthDelegate{})
 }
 
 func TestImport(t *testing.T) {
@@ -90,7 +90,7 @@ func TestLogin(t *testing.T) {
 		sv, err := NewMockServer(ctx)
 		assert.Nil(t, err)
 		client := NewRemoteFoxgloveClient(sv.BaseURL(), "abc", "", "test-app")
-		bearerToken, err := Login(ctx, client)
+		bearerToken, err := Login(ctx, client, &MockAuthDelegate{})
 		assert.Nil(t, err)
 		assert.NotEmpty(t, bearerToken)
 	})
@@ -100,7 +100,7 @@ func TestLogin(t *testing.T) {
 		sv, err := NewMockServer(ctx)
 		assert.Nil(t, err)
 		client := NewRemoteFoxgloveClient(sv.BaseURL(), "abc", "", "test-app")
-		bearerToken, err := Login(ctx, client)
+		bearerToken, err := Login(ctx, client, &MockAuthDelegate{})
 		assert.ErrorIs(t, context.Canceled, err)
 		assert.Empty(t, bearerToken)
 	})

--- a/foxglove/console/mock_service.go
+++ b/foxglove/console/mock_service.go
@@ -9,6 +9,8 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -337,4 +339,13 @@ func NewMockServer(ctx context.Context) (*MockFoxgloveServer, error) {
 		}
 	}
 	return sv, nil
+}
+
+// provides a no-op implementation of `openBrowser`
+type MockAuthDelegate struct{}
+
+func (del *MockAuthDelegate) openBrowser(url string) (*exec.Cmd, error) {
+	return &exec.Cmd{
+		Process: &os.Process{},
+	}, nil
 }


### PR DESCRIPTION
**Public-Facing Changes**

None.

**Description**

On macOS, the implementation of `openBrowser` shells out to `open`, which spawns Finder windows during test runs. This adds a stub for tests to prevent this from happening.