### PR TITLE
Support extension unpublishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,9 +178,14 @@ $ foxglove data export --device-id dev_flm75pLkfzUBX2DH --start 2001-01-01T00:00
 
 #### Studio extensions
 
-With a paid foxglove account, you can upload [Studio extensions](https://foxglove.dev/docs/studio/extensions/getting-started) to share with your organization.
+With a paid foxglove account, you can upload
+[Studio extensions](https://foxglove.dev/docs/studio/extensions/getting-started)
+to share with your organization.
 
-Extensions are created and packaged with the [foxglove-extension](https://github.com/foxglove/create-foxglove-extension/) tool. The latest version of each uploaded extension will be installed in Studio for all organization members.
+Extensions are created and packaged with the
+[foxglove-extension](https://github.com/foxglove/create-foxglove-extension/)
+tool. The latest version of each uploaded extension will be installed in Studio
+for all organization members.
 
 To publish a new extension, or update one with a newer version:
 
@@ -196,7 +201,9 @@ foxglove extensions list
 
 You can use the global `--format` flag to change the output type.
 
-To unpublish an extension, use the ID listed from the above command. This will **delete** your extension files and cause the extension to be uninstalled from Studio for all organization members.
+To unpublish an extension, use the ID listed from the above command. This will
+**delete** your extension files and cause the extension to be uninstalled from
+Studio for all organization members.
 
 ```
 foxglove extensions unpublish ext_BsGXKGsZ9c4WQF1

--- a/README.md
+++ b/README.md
@@ -194,6 +194,14 @@ To list your extensions:
 foxglove extensions list
 ```
 
+You can use the global `--format` flag to change the output type.
+
+To unpublish an extension, use the ID listed from the above command. This will **delete** your extension files and cause the extension to be uninstalled from Studio for all organization members.
+
+```
+foxglove extensions unpublish ext_BsGXKGsZ9c4WQF1
+```
+
 ### Shell autocompletion
 
 The foxglove tool supports shell autocompletion for subcommands and some kinds

--- a/README.md
+++ b/README.md
@@ -188,6 +188,12 @@ To publish a new extension, or update one with a newer version:
 foxglove extensions upload ./my-extension.1.0.0.foxe
 ```
 
+To list your extensions:
+
+```
+foxglove extensions list
+```
+
 ### Shell autocompletion
 
 The foxglove tool supports shell autocompletion for subcommands and some kinds

--- a/README.md
+++ b/README.md
@@ -199,6 +199,22 @@ To list your extensions:
 foxglove extensions list
 ```
 
+Example JSON output:
+
+```json
+[
+    {
+        "id": "ext_BsGXKGsZ9c4WQF1",
+        "name": "my_new_panel",
+        "publisher": "panel-publisher",
+        "displayName": "My New Panel",
+        "description": "Creates a panel",
+        "activeVersion": "1.0.0",
+        "sha256Sum": "395c3af8745ab104cd902d937366719a402bda4677ed3671cb38522c1ba13cbe"
+    }
+]
+```
+
 You can use the global `--format` flag to change the output type.
 
 To unpublish an extension, use the ID listed from the above command. This will

--- a/foxglove/cmd/extensions.go
+++ b/foxglove/cmd/extensions.go
@@ -21,6 +21,10 @@ func executeExtensionUpload(baseURL, clientID, token, filename, userAgent string
 	return console.UploadExtensionFile(ctx, client, filename)
 }
 
+func executeExtensionDelete(client *console.FoxgloveClient, extensionId string) error {
+	return client.DeleteExtension(extensionId)
+}
+
 func newPublishExtensionCommand(params *baseParams) *cobra.Command {
 	uploadCmd := &cobra.Command{
 		Use:   "publish [FILE]",
@@ -71,4 +75,25 @@ func newListExtensionsCommand(params *baseParams) *cobra.Command {
 	listCmd.InheritedFlags()
 	AddFormatFlag(listCmd, &format)
 	return listCmd
+}
+
+func newUnpublishExtensionCommand(params *baseParams) *cobra.Command {
+	deleteCmd := &cobra.Command{
+		Use:   "unpublish [ID]",
+		Short: "Unpublish and delete a Studio extension from your organization",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			client := console.NewRemoteFoxgloveClient(
+				*params.baseURL, *params.clientID,
+				viper.GetString("bearer_token"),
+				params.userAgent,
+			)
+			err := executeExtensionDelete(client, args[0])
+			if err != nil {
+				fatalf("Failed to unpublish extension: %s\n", err)
+			}
+		},
+	}
+	deleteCmd.InheritedFlags()
+	return deleteCmd
 }

--- a/foxglove/cmd/extensions.go
+++ b/foxglove/cmd/extensions.go
@@ -77,7 +77,7 @@ func newListExtensionsCommand(params *baseParams) *cobra.Command {
 func newUnpublishExtensionCommand(params *baseParams) *cobra.Command {
 	deleteCmd := &cobra.Command{
 		Use:   "unpublish [ID]",
-		Short: "Unpublish and delete a Studio extension from your organization",
+		Short: "Delete and unpublish a Studio extension from your organization",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			client := console.NewRemoteFoxgloveClient(
@@ -87,8 +87,9 @@ func newUnpublishExtensionCommand(params *baseParams) *cobra.Command {
 			)
 			err := executeExtensionDelete(client, args[0])
 			if err != nil {
-				fatalf("Failed to unpublish extension: %s\n", err)
+				fatalf("Failed to delete extension: %s\n", err)
 			}
+			fmt.Println("Extension deleted")
 		},
 	}
 	deleteCmd.InheritedFlags()

--- a/foxglove/cmd/extensions.go
+++ b/foxglove/cmd/extensions.go
@@ -10,14 +10,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-func executeExtensionUpload(baseURL, clientID, token, filename, userAgent string) error {
+func executeExtensionUpload(client *console.FoxgloveClient, filename string) error {
 	ctx := context.Background()
-	client := console.NewRemoteFoxgloveClient(
-		baseURL,
-		clientID,
-		token,
-		userAgent,
-	)
 	return console.UploadExtensionFile(ctx, client, filename)
 }
 
@@ -32,12 +26,15 @@ func newPublishExtensionCommand(params *baseParams) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			filename := args[0] // guaranteed length 1 due to Args setting above
-			err := executeExtensionUpload(
+			client := console.NewRemoteFoxgloveClient(
 				*params.baseURL,
 				*params.clientID,
 				viper.GetString("bearer_token"),
-				filename,
 				params.userAgent,
+			)
+			err := executeExtensionUpload(
+				client,
+				filename,
 			)
 			if err != nil {
 				fatalf("Extension upload failed: %s\n", err)

--- a/foxglove/cmd/extensions_test.go
+++ b/foxglove/cmd/extensions_test.go
@@ -9,20 +9,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUploadExtensionCommand(t *testing.T) {
+func TestPublishExtensionCommand(t *testing.T) {
 	ctx := context.Background()
 	t.Run("returns forbidden if not authenticated", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
 		sv, err := console.NewMockServer(ctx)
 		assert.Nil(t, err)
-		err = executeExtensionUpload(
+		client := console.NewRemoteFoxgloveClient(
 			sv.BaseURL(),
 			"client",
 			"token",
-			"../testdata/fg.mock-0.0.0.foxe",
 			"user-agent",
 		)
+		err = executeExtensionUpload(client, "../testdata/fg.mock-0.0.0.foxe")
 		assert.ErrorIs(t, err, console.ErrForbidden)
 	})
 	t.Run("returns friendly error for unexpected file extension", func(t *testing.T) {
@@ -30,13 +30,13 @@ func TestUploadExtensionCommand(t *testing.T) {
 		defer cancel()
 		sv, err := console.NewMockServer(ctx)
 		assert.Nil(t, err)
-		err = executeExtensionUpload(
+		client := console.NewRemoteFoxgloveClient(
 			sv.BaseURL(),
 			"client",
 			"token",
-			"../testdata/gps.bag",
 			"user-agent",
 		)
+		err = executeExtensionUpload(client, "../testdata/gps.bag")
 		assert.EqualError(t, err, "file should have a '.foxe' extension")
 	})
 }

--- a/foxglove/cmd/extensions_test.go
+++ b/foxglove/cmd/extensions_test.go
@@ -40,3 +40,44 @@ func TestUploadExtensionCommand(t *testing.T) {
 		assert.EqualError(t, err, "file should have a '.foxe' extension")
 	})
 }
+
+func TestUnpublishExtensionCommand(t *testing.T) {
+	ctx := context.Background()
+	t.Run("returns ok if deleted", func(t *testing.T) {
+		sv, err := console.NewMockServer(ctx)
+		assert.Nil(t, err)
+		client := newAuthedClient(t, sv.BaseURL())
+		err = executeExtensionDelete(
+			client,
+			sv.ValidExtensionId(),
+		)
+		assert.Nil(t, err)
+	})
+	t.Run("does not error if extension not found", func(t *testing.T) {
+		sv, err := console.NewMockServer(ctx)
+		assert.Nil(t, err)
+		client := newAuthedClient(t, sv.BaseURL())
+		err = executeExtensionDelete(
+			client,
+			"nonexistent-extension-id",
+		)
+		assert.Nil(t, err)
+	})
+}
+
+func newAuthedClient(t *testing.T, baseUrl string) *console.FoxgloveClient {
+	client := console.NewRemoteFoxgloveClient(
+		baseUrl,
+		"client",
+		"",
+		"user-agent",
+	)
+	token, err := client.SignIn("client-id")
+	assert.Nil(t, err)
+	return console.NewRemoteFoxgloveClient(
+		baseUrl,
+		"client",
+		token,
+		"user-agent",
+	)
+}

--- a/foxglove/cmd/root.go
+++ b/foxglove/cmd/root.go
@@ -150,6 +150,7 @@ func Execute(version string) {
 	eventsCmd.AddCommand(newListEventsCommand(params), newAddEventCommand(params))
 	extensionsCmd.AddCommand(newListExtensionsCommand(params))
 	extensionsCmd.AddCommand(newPublishExtensionCommand(params))
+	extensionsCmd.AddCommand(newUnpublishExtensionCommand(params))
 
 	rootCmd.AddCommand(authCmd, dataCmd, newVersionCommand(version), devicesCmd, betaCmd, extensionsCmd)
 

--- a/foxglove/console/client.go
+++ b/foxglove/console/client.go
@@ -181,6 +181,8 @@ func (c *FoxgloveClient) post(
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
+	defer resp.Body.Close()
+
 	switch resp.StatusCode {
 	case http.StatusForbidden:
 		return ErrForbidden
@@ -206,6 +208,7 @@ func (c *FoxgloveClient) delete(endpoint string) error {
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
+	defer resp.Body.Close()
 
 	switch resp.StatusCode {
 	case http.StatusForbidden:
@@ -241,19 +244,19 @@ func (c *FoxgloveClient) UploadExtension(reader io.Reader) error {
 		return fmt.Errorf("failed to build upload extension request: %w", err)
 	}
 	req.Header.Add("Content-Type", "application/octet-stream")
-	res, err := c.authed.Do(req)
+	resp, err := c.authed.Do(req)
 	if err != nil {
 		return fmt.Errorf("extension upload failure: %w", err)
 	}
-	defer res.Body.Close()
+	defer resp.Body.Close()
 
-	switch res.StatusCode {
+	switch resp.StatusCode {
 	case http.StatusOK:
 		return nil
 	case http.StatusForbidden, http.StatusUnauthorized:
-		return fmt.Errorf("%w\n%s", ErrForbidden, unpackErrorResponse(res.Body))
+		return fmt.Errorf("%w\n%s", ErrForbidden, unpackErrorResponse(resp.Body))
 	default:
-		return unpackErrorResponse(res.Body)
+		return unpackErrorResponse(resp.Body)
 	}
 }
 

--- a/foxglove/console/client.go
+++ b/foxglove/console/client.go
@@ -212,7 +212,7 @@ func (c *FoxgloveClient) delete(endpoint string) error {
 		return ErrForbidden
 	case http.StatusNotFound:
 		// Warn the user, but proceed as successful
-		fmt.Fprintf(os.Stderr, "Not found. The resource may have already been deleted.")
+		fmt.Fprintln(os.Stderr, "Not found. The resource may have already been deleted.")
 	case http.StatusOK:
 		break
 	default:


### PR DESCRIPTION
**Public-Facing Changes**

This adds support for extension unpublishing (deletion).

**Description**

Some points of discussion, since we don't have any existing delete functionality:

- `FoxgloveClient.delete` does not treat a 404 as a failure; the command will exit with 0 but write a warning to stderr
- Otherwise, a successful delete produces no output
- The command "unpublish" is symmetric with "unpublish", but this does delete data as described in the docs & help

Resolves #65.