### PR TITLE
Write error & human-friendly messages to stderr

### DIFF
--- a/foxglove/cmd/devices.go
+++ b/foxglove/cmd/devices.go
@@ -27,7 +27,7 @@ func newListDevicesCommand(params *baseParams) *cobra.Command {
 				format,
 			)
 			if err != nil {
-				fmt.Printf("Failed to list devices: %s\n", err)
+				fmt.Fprintf(os.Stderr, "Failed to list devices: %s\n", err)
 			}
 		},
 	}
@@ -55,7 +55,7 @@ func newAddDeviceCommand(params *baseParams) *cobra.Command {
 			if err != nil {
 				fatalf("Failed to create device: %s\n", err)
 			}
-			fmt.Printf("Device created: %s\n", resp.ID)
+			fmt.Fprintf(os.Stderr, "Device created: %s\n", resp.ID)
 		},
 	}
 	addDeviceCmd.InheritedFlags()

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -30,7 +30,7 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 			for _, kv := range keyvals {
 				parts := strings.FieldsFunc(kv, func(c rune) bool { return c == ':' })
 				if len(parts) != 2 {
-					fmt.Printf("Invalid key/value pair: %s\n", kv)
+					fmt.Fprintf(os.Stderr, "Invalid key/value pair: %s\n", kv)
 					os.Exit(1)
 				}
 				metadata[parts[0]] = parts[1]
@@ -43,10 +43,10 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 				Metadata:      metadata,
 			})
 			if err != nil {
-				fmt.Printf("Failed to add event: %s\n", err)
+				fmt.Fprintf(os.Stderr, "Failed to add event: %s\n", err)
 				os.Exit(1)
 			}
-			fmt.Printf("Created event: %s\n", response.ID)
+			fmt.Fprintf(os.Stderr, "Created event: %s\n", response.ID)
 		},
 	}
 	addEventCmd.PersistentFlags().StringVarP(&deviceID, "device-id", "", "", "Device ID")

--- a/foxglove/cmd/extensions.go
+++ b/foxglove/cmd/extensions.go
@@ -39,7 +39,7 @@ func newPublishExtensionCommand(params *baseParams) *cobra.Command {
 			if err != nil {
 				fatalf("Extension upload failed: %s\n", err)
 			}
-			fmt.Println("Extension published")
+			fmt.Fprintln(os.Stderr, "Extension published")
 		},
 	}
 	uploadCmd.InheritedFlags()
@@ -89,7 +89,7 @@ func newUnpublishExtensionCommand(params *baseParams) *cobra.Command {
 			if err != nil {
 				fatalf("Failed to delete extension: %s\n", err)
 			}
-			fmt.Println("Extension deleted")
+			fmt.Fprintln(os.Stderr, "Extension deleted")
 		},
 	}
 	deleteCmd.InheritedFlags()

--- a/foxglove/cmd/imports.go
+++ b/foxglove/cmd/imports.go
@@ -40,7 +40,7 @@ func newListImportsCommand(params *baseParams) *cobra.Command {
 				format,
 			)
 			if err != nil {
-				fmt.Printf("Failed to list imports: %s\n", err)
+				fmt.Fprintf(os.Stderr, "Failed to list imports: %s\n", err)
 				os.Exit(1)
 			}
 		},


### PR DESCRIPTION
**Public-Facing Changes**

This updates CLI output in places to write to stderr. In a few places, we were logging errors to stdout. In a few other places, this updates non-error messages intended for interactive/human consumption (like "extension published") to stderr as well.

**Description**

Following up on https://github.com/foxglove/foxglove-cli/pull/67#discussion_r932647140. There's precedent in other tools to write human-friendly messages to stderr, distinct from formatted API output (table, csv, etc).