### PR TITLE
Drop support for legacy mcap

### DIFF
--- a/foxglove/cmd/export.go
+++ b/foxglove/cmd/export.go
@@ -28,6 +28,7 @@ import (
 
 var (
 	ErrRedirectStdout = errors.New("stdout unredirected")
+	ErrInvalidFormat  = errors.New("invalid format: supply mcap0, bag1, or json")
 )
 
 type DecimalTime uint64
@@ -176,11 +177,22 @@ func stdoutRedirected() bool {
 	return true
 }
 
+func validOutputFormat(format string) bool {
+	return map[string]bool{
+		"mcap0": true,
+		"bag1":  true,
+		"json":  true,
+	}[format]
+}
+
 func executeExport(
 	ctx context.Context,
 	w io.Writer,
 	baseURL, clientID, deviceID, start, end, outputFormat, topicList, bearerToken, userAgent string,
 ) error {
+	if !validOutputFormat(outputFormat) {
+		return ErrInvalidFormat
+	}
 	client := console.NewRemoteFoxgloveClient(
 		baseURL,
 		clientID,
@@ -256,7 +268,7 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 	exportCmd.PersistentFlags().StringVarP(&deviceID, "device-id", "", "", "device ID")
 	exportCmd.PersistentFlags().StringVarP(&start, "start", "", "", "start time (RFC3339 timestamp)")
 	exportCmd.PersistentFlags().StringVarP(&end, "end", "", "", "end time (RFC3339 timestamp")
-	exportCmd.PersistentFlags().StringVarP(&outputFormat, "output-format", "", "", "output format")
+	exportCmd.PersistentFlags().StringVarP(&outputFormat, "output-format", "", "mcap0", "output format (mcap0, bag1, or json)")
 	exportCmd.PersistentFlags().StringVarP(&topicList, "topics", "", "", "comma separated list of topics")
 	err := exportCmd.MarkPersistentFlagRequired("device-id")
 	if err != nil {

--- a/foxglove/cmd/export_test.go
+++ b/foxglove/cmd/export_test.go
@@ -52,12 +52,33 @@ func TestExportCommand(t *testing.T) {
 			"test-device",
 			"2020-01-01T00:00:00Z",
 			"2021-01-01T00:00:00Z",
-			"mcap",
+			"mcap0",
 			"/diagnostics",
 			"",
 			"user-agent",
 		)
 		assert.ErrorIs(t, err, console.ErrForbidden)
+	})
+	t.Run("returns error on invalid format", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+		buf := &bytes.Buffer{}
+		sv, err := console.NewMockServer(ctx)
+		assert.Nil(t, err)
+		err = executeExport(
+			ctx,
+			buf,
+			sv.BaseURL(),
+			"abc",
+			"test-device",
+			"2020-01-01T00:00:00Z",
+			"2021-01-01T00:00:00Z",
+			"mcap",
+			"/diagnostics",
+			"",
+			"user-agent",
+		)
+		assert.ErrorIs(t, err, ErrInvalidFormat)
 	})
 	t.Run("returns empty data when requesting data that does not exist", func(t *testing.T) {
 		buf := &bytes.Buffer{}
@@ -77,7 +98,7 @@ func TestExportCommand(t *testing.T) {
 				"test-device",
 				"2020-01-01T00:00:00Z",
 				"2021-01-01T00:00:00Z",
-				"mcap",
+				"mcap0",
 				"/diagnostics",
 				token,
 				"user-agent",


### PR DESCRIPTION
Drops support for legacy mcap output, and returns an error if none of
mcap0, bag1, or json is specified.