### PR TITLE
Enable streaming by import ID

### DIFF
--- a/foxglove/cmd/export_test.go
+++ b/foxglove/cmd/export_test.go
@@ -38,6 +38,10 @@ func withStdoutRedirected(output io.Writer, f func()) error {
 
 func TestExportCommand(t *testing.T) {
 	ctx := context.Background()
+	start, err := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+	assert.Nil(t, err)
+	end, err := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
+	assert.Nil(t, err)
 	t.Run("returns forbidden if not authenticated", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
@@ -45,17 +49,19 @@ func TestExportCommand(t *testing.T) {
 		sv, err := console.NewMockServer(ctx)
 		assert.Nil(t, err)
 		err = executeExport(
-			context.TODO(),
+			ctx,
 			buf,
 			sv.BaseURL(),
-			"abc",
-			"test-device",
-			"2020-01-01T00:00:00Z",
-			"2021-01-01T00:00:00Z",
-			"mcap0",
-			"/diagnostics",
 			"",
+			"abc",
 			"user-agent",
+			&console.StreamRequest{
+				DeviceID:     "test-device",
+				Start:        &start,
+				End:          &end,
+				OutputFormat: "mcap0",
+				Topics:       []string{"/diagnostics"},
+			},
 		)
 		assert.ErrorIs(t, err, console.ErrForbidden)
 	})
@@ -69,14 +75,16 @@ func TestExportCommand(t *testing.T) {
 			ctx,
 			buf,
 			sv.BaseURL(),
-			"abc",
-			"test-device",
-			"2020-01-01T00:00:00Z",
-			"2021-01-01T00:00:00Z",
-			"mcap",
-			"/diagnostics",
 			"",
+			"abc",
 			"user-agent",
+			&console.StreamRequest{
+				DeviceID:     "test-device",
+				Start:        &start,
+				End:          &end,
+				OutputFormat: "mcap",
+				Topics:       []string{"/diagnostics"},
+			},
 		)
 		assert.ErrorIs(t, err, ErrInvalidFormat)
 	})
@@ -91,17 +99,19 @@ func TestExportCommand(t *testing.T) {
 			token, err := client.SignIn("client-id")
 			assert.Nil(t, err)
 			err = executeExport(
-				context.TODO(),
+				ctx,
 				buf,
 				sv.BaseURL(),
 				"abc",
-				"test-device",
-				"2020-01-01T00:00:00Z",
-				"2021-01-01T00:00:00Z",
-				"mcap0",
-				"/diagnostics",
 				token,
 				"user-agent",
+				&console.StreamRequest{
+					DeviceID:     "test-device",
+					Start:        &start,
+					End:          &end,
+					OutputFormat: "mcap0",
+					Topics:       []string{"/diagnostics"},
+				},
 			)
 			assert.Nil(t, err)
 		})
@@ -128,19 +138,23 @@ func TestExportCommand(t *testing.T) {
 			"user-agent",
 		)
 		assert.Nil(t, err)
+		start, err := time.Parse(time.RFC3339, "2001-01-01T00:00:00Z")
+		assert.Nil(t, err)
 		err = withStdoutRedirected(buf, func() {
 			err := executeExport(
-				context.TODO(),
+				ctx,
 				buf,
 				sv.BaseURL(),
-				clientID,
-				deviceID,
-				"2001-01-01T00:00:00Z",
-				"2021-01-01T00:00:00Z",
-				"bag1",
-				"/diagnostics",
+				"abc",
 				token,
 				"user-agent",
+				&console.StreamRequest{
+					DeviceID:     "test-device",
+					Start:        &start,
+					End:          &end,
+					OutputFormat: "bag1",
+					Topics:       []string{"/diagnostics"},
+				},
 			)
 			assert.Nil(t, err)
 		})
@@ -167,19 +181,23 @@ func TestExportCommand(t *testing.T) {
 			"user-agent",
 		)
 		assert.Nil(t, err)
+		start, err := time.Parse(time.RFC3339, "2001-01-01T00:00:00Z")
+		assert.Nil(t, err)
 		err = withStdoutRedirected(buf, func() {
 			err := executeExport(
-				context.TODO(),
+				ctx,
 				buf,
 				sv.BaseURL(),
-				clientID,
-				deviceID,
-				"2001-01-01T00:00:00Z",
-				"2021-01-01T00:00:00Z",
-				"json",
-				"/diagnostics",
+				"abc",
 				token,
 				"user-agent",
+				&console.StreamRequest{
+					DeviceID:     "test-device",
+					Start:        &start,
+					End:          &end,
+					OutputFormat: "json",
+					Topics:       []string{"/diagnostics"},
+				},
 			)
 			assert.Nil(t, err)
 		})

--- a/foxglove/console/api.go
+++ b/foxglove/console/api.go
@@ -105,7 +105,6 @@ type ImportsRequest struct {
 
 type ImportsResponse struct {
 	ID              string    `json:"id"`
-	ImportID        string    `json:"importId"`
 	DeviceID        string    `json:"deviceId"`
 	Filename        string    `json:"filename"`
 	ImportTime      time.Time `json:"importTime"`
@@ -120,7 +119,6 @@ type ImportsResponse struct {
 func (r ImportsResponse) Fields() []string {
 	return []string{
 		r.ID,
-		r.ImportID,
 		r.DeviceID,
 		r.Filename,
 		r.ImportTime.Format(time.RFC3339),
@@ -135,7 +133,6 @@ func (r ImportsResponse) Fields() []string {
 
 func (r ImportsResponse) Headers() []string {
 	return []string{
-		"ID",
 		"Import ID",
 		"Device ID",
 		"Filename",

--- a/foxglove/console/api.go
+++ b/foxglove/console/api.go
@@ -32,11 +32,22 @@ type UploadResponse struct {
 }
 
 type StreamRequest struct {
-	DeviceID     string    `json:"deviceId"`
-	Start        time.Time `json:"start"`
-	End          time.Time `json:"end"`
-	OutputFormat string    `json:"outputFormat"`
-	Topics       []string  `json:"topics"`
+	ImportID     string     `json:"importId"`
+	DeviceID     string     `json:"deviceId"`
+	Start        *time.Time `json:"start,omitempty"`
+	End          *time.Time `json:"end,omitempty"`
+	OutputFormat string     `json:"outputFormat"`
+	Topics       []string   `json:"topics"`
+}
+
+func (req *StreamRequest) Validate() error {
+	if req.ImportID == "" && req.DeviceID == "" {
+		return fmt.Errorf("device-id or import-id is required")
+	}
+	if req.DeviceID != "" && req.ImportID == "" && (req.Start == nil || req.End == nil) {
+		return fmt.Errorf("start/end are required if device-id is supplied")
+	}
+	return nil
 }
 
 type StreamResponse struct {
@@ -93,6 +104,7 @@ type ImportsRequest struct {
 }
 
 type ImportsResponse struct {
+	ID              string    `json:"id"`
 	ImportID        string    `json:"importId"`
 	DeviceID        string    `json:"deviceId"`
 	Filename        string    `json:"filename"`
@@ -107,6 +119,7 @@ type ImportsResponse struct {
 
 func (r ImportsResponse) Fields() []string {
 	return []string{
+		r.ID,
 		r.ImportID,
 		r.DeviceID,
 		r.Filename,
@@ -122,6 +135,7 @@ func (r ImportsResponse) Fields() []string {
 
 func (r ImportsResponse) Headers() []string {
 	return []string{
+		"ID",
 		"Import ID",
 		"Device ID",
 		"Filename",

--- a/foxglove/console/api.go
+++ b/foxglove/console/api.go
@@ -42,10 +42,13 @@ type StreamRequest struct {
 
 func (req *StreamRequest) Validate() error {
 	if req.ImportID == "" && req.DeviceID == "" {
-		return fmt.Errorf("device-id or import-id is required")
+		return fmt.Errorf("either import-id or device-id, start, and end are required")
 	}
 	if req.DeviceID != "" && req.ImportID == "" && (req.Start == nil || req.End == nil) {
 		return fmt.Errorf("start/end are required if device-id is supplied")
+	}
+	if req.Start != nil && req.End != nil && req.End.Before(*req.Start) {
+		return fmt.Errorf("end must be after or equal to start")
 	}
 	return nil
 }

--- a/foxglove/console/client.go
+++ b/foxglove/console/client.go
@@ -66,7 +66,7 @@ func (c *FoxgloveClient) SignIn(token string) (string, error) {
 
 // Stream returns a ReadCloser wrapping a binary output stream in response to
 // the provided request.
-func (c *FoxgloveClient) Stream(r StreamRequest) (io.ReadCloser, error) {
+func (c *FoxgloveClient) Stream(r *StreamRequest) (io.ReadCloser, error) {
 	buf := &bytes.Buffer{}
 	err := json.NewEncoder(buf).Encode(r)
 	if err != nil {

--- a/foxglove/console/lib.go
+++ b/foxglove/console/lib.go
@@ -44,27 +44,9 @@ func Export(
 	ctx context.Context,
 	w io.Writer,
 	client *FoxgloveClient,
-	deviceID string,
-	startstr string,
-	endstr string,
-	topics []string,
-	outputFormat string,
+	request *StreamRequest,
 ) error {
-	start, err := time.Parse(time.RFC3339, startstr)
-	if err != nil {
-		return fmt.Errorf("failed to parse start: %w", err)
-	}
-	end, err := time.Parse(time.RFC3339, endstr)
-	if err != nil {
-		return fmt.Errorf("failed to parse start: %w", err)
-	}
-	rc, err := client.Stream(StreamRequest{
-		DeviceID:     deviceID,
-		Start:        start,
-		End:          end,
-		OutputFormat: outputFormat,
-		Topics:       topics,
-	})
+	rc, err := client.Stream(request)
 	if err != nil {
 		return err
 	}

--- a/foxglove/console/lib_test.go
+++ b/foxglove/console/lib_test.go
@@ -49,7 +49,18 @@ func TestExport(t *testing.T) {
 		assert.Nil(t, err)
 		client := NewRemoteFoxgloveClient(sv.BaseURL(), "abc", "", "test-app")
 		buf := &bytes.Buffer{}
-		err = Export(ctx, buf, client, "test-device", "2020-01-01T00:00:00Z", "2021-01-01T00:00:00Z", []string{}, "mcap")
+		start, err := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+		assert.Nil(t, err)
+		end, err := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
+		assert.Nil(t, err)
+		err = Export(ctx, buf, client, &StreamRequest{
+			DeviceID:     "test-device",
+			Start:        &start,
+			End:          &end,
+			Topics:       []string{},
+			OutputFormat: "mcap",
+		},
+		)
 		assert.ErrorIs(t, err, ErrForbidden)
 	})
 	t.Run("returns empty data when nothing matches", func(t *testing.T) {
@@ -61,7 +72,18 @@ func TestExport(t *testing.T) {
 		assert.Nil(t, err)
 		client := NewRemoteFoxgloveClient(sv.BaseURL(), "abc", token, "test-app")
 		buf := &bytes.Buffer{}
-		err = Export(ctx, buf, client, "test-device", "2020-01-01T00:00:00Z", "2021-01-01T00:00:00Z", []string{}, "mcap")
+		start, err := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+		assert.Nil(t, err)
+		end, err := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
+		assert.Nil(t, err)
+		err = Export(ctx, buf, client, &StreamRequest{
+			DeviceID:     "test-device",
+			Start:        &start,
+			End:          &end,
+			Topics:       []string{},
+			OutputFormat: "mcap",
+		},
+		)
 		assert.Nil(t, err)
 		assert.Empty(t, buf.Bytes())
 	})
@@ -76,8 +98,18 @@ func TestExport(t *testing.T) {
 		buf := &bytes.Buffer{}
 		err = Import(ctx, client, "test-device", "../testdata/gps.bag")
 		assert.Nil(t, err)
-		err = Export(ctx, buf, client, "test-device", "2020-01-01T00:00:00Z", "2021-01-01T00:00:00Z", []string{}, "mcap")
+		start, err := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
 		assert.Nil(t, err)
+		end, err := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
+		assert.Nil(t, err)
+		err = Export(ctx, buf, client, &StreamRequest{
+			DeviceID:     "test-device",
+			Start:        &start,
+			End:          &end,
+			Topics:       []string{},
+			OutputFormat: "mcap",
+		},
+		)
 		assert.NotEmpty(t, buf.Bytes())
 	})
 }

--- a/foxglove/console/lib_test.go
+++ b/foxglove/console/lib_test.go
@@ -110,6 +110,7 @@ func TestExport(t *testing.T) {
 			OutputFormat: "mcap",
 		},
 		)
+		assert.Nil(t, err)
 		assert.NotEmpty(t, buf.Bytes())
 	})
 }

--- a/foxglove/console/mock_service.go
+++ b/foxglove/console/mock_service.go
@@ -151,9 +151,9 @@ func (s *MockFoxgloveServer) imports(w http.ResponseWriter, r *http.Request) {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 	imports := []ImportsResponse{}
-	for key := range s.Uploads {
+	for importID := range s.Uploads {
 		imports = append(imports, ImportsResponse{
-			ImportID: key,
+			ID: importID,
 		})
 	}
 	err := json.NewEncoder(w).Encode(imports)


### PR DESCRIPTION
Adds an --import-id flag to the export command to allow downloading data by import ID.