### PR TITLE
Enable noninteractive configuration of API keys

### DIFF
--- a/foxglove/cmd/configure_api_key.go
+++ b/foxglove/cmd/configure_api_key.go
@@ -7,11 +7,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-func configureAPIKey() error {
-	fmt.Printf("Enter an API key (will be written to %s):\n", viper.ConfigFileUsed())
-	var bearerToken string
-	fmt.Scanln(&bearerToken)
-	viper.Set("bearer_token", bearerToken)
+func setBearerToken(token string) error {
+	viper.Set("bearer_token", token)
 	err := viper.WriteConfigAs(viper.ConfigFileUsed())
 	if err != nil {
 		return fmt.Errorf("Failed to write config: %w", err)
@@ -20,16 +17,22 @@ func configureAPIKey() error {
 }
 
 func newConfigureAPIKeyCommand() *cobra.Command {
+	var token string
 	configCmd := &cobra.Command{
 		Use:   "configure-api-key",
 		Short: "Configure an API key",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := configureAPIKey()
+			if token == "" {
+				prompt := fmt.Sprintf("Enter an API key (will be written to %s):\n", viper.ConfigFileUsed())
+				token = promptForInput(prompt)
+			}
+			err := setBearerToken(token)
 			if err != nil {
 				fatalf("Configuration failed: %s\n", err)
 			}
 		},
 	}
+	configCmd.PersistentFlags().StringVarP(&token, "api-key", "", "", "api key (for non-interactive use)")
 	configCmd.InheritedFlags()
 	return configCmd
 }

--- a/foxglove/cmd/utils.go
+++ b/foxglove/cmd/utils.go
@@ -101,3 +101,10 @@ func AddFormatFlag(cmd *cobra.Command, format *string) {
 		"render output in specified format (table, json, csv)",
 	)
 }
+
+func promptForInput(prompt string) string {
+	fmt.Printf(prompt)
+	var value string
+	fmt.Scanln(&value)
+	return value
+}


### PR DESCRIPTION
Adds an --api-key parameter to the configure-api-key subcommand, to allow noninteractive scripts to configure API keys.