### PR TITLE
Don't send empty values for import/device ID

### DIFF
--- a/foxglove/console/api.go
+++ b/foxglove/console/api.go
@@ -32,8 +32,8 @@ type UploadResponse struct {
 }
 
 type StreamRequest struct {
-	ImportID     string     `json:"importId"`
-	DeviceID     string     `json:"deviceId"`
+	ImportID     string     `json:"importId,omitempty"`
+	DeviceID     string     `json:"deviceId,omitempty"`
 	Start        *time.Time `json:"start,omitempty"`
 	End          *time.Time `json:"end,omitempty"`
 	OutputFormat string     `json:"outputFormat"`


### PR DESCRIPTION
Prior to this commit, the tool was sending empty strings in the importID and deviceID fields when no import/device was supplied.

This has caused an issue with a recent change on the backend that started doing an erroneous lookup based on the empty string. The fix for that issue will be implemented on the backend rather than requiring a CLI upgrade for users - but the CLI should not be sending these unpopulated fields in any case.