### PR TITLE
Add [v1] events commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,24 +121,14 @@ Device created: dev_drpLqjBZYUzus3gv
 The tool supports creating and searching events:
 
 ```
-$ foxglove beta events list
-|          ID          |      DEVICE ID       |      TIMESTAMP      |  DURATION   |        CREATED AT        |        UPDATED AT        |                                 METADATA                                 |
-|----------------------|----------------------|---------------------|-------------|--------------------------|--------------------------|--------------------------------------------------------------------------|
-| evt_PbkdOL8geyyXLIOr | dev_JtSXCGiM0RC2YHDO | 1532402927000000000 | 0           | 2022-02-24T15:22:25.154Z | 2022-02-24T15:22:25.154Z | {"position":"start"}                                                     |
-| evt_U0TCTtRbDb631tmI | dev_mHH1Cp4gPybCPR8y | 1532402927000000000 | 2000000000  | 2022-02-09T21:11:52.637Z | 2022-02-09T21:11:52.637Z | {"nuscene":"0061","startup":"yes"}                                       |
-| evt_9akLLRJRqp8jg1zq | dev_mHH1Cp4gPybCPR8y | 1532402927000000000 | 19000000000 | 2022-02-09T21:08:46.936Z | 2022-02-09T21:08:46.936Z | {"location":"singapore","nuscene":"0061","weather-laguna":"really-nice"} |
-| evt_0A1LUzWBKkLeDoIa | dev_mHH1Cp4gPybCPR8y | 1532402937000000000 | 0           | 2022-02-09T21:19:18.488Z | 2022-02-09T21:19:18.488Z | {"nuscene":"0061","random":"yes"}                                        |
-| evt_Nx6Nx9WoEMPhDeRb | dev_mHH1Cp4gPybCPR8y | 1532402937000000000 | 0           | 2022-02-09T22:08:51.249Z | 2022-02-09T22:08:51.249Z | {"location":"🇸🇬"}                                                         |
-| evt_zZ8s6al5F3CUYVtJ | dev_mHH1Cp4gPybCPR8y | 1532402937000000000 | 0           | 2022-02-09T22:09:49.412Z | 2022-02-09T22:09:49.412Z | {"weather":"🌧"}                                                          |
-| evt_zEVu8NABeHZdABML | dev_mHH1Cp4gPybCPR8y | 1644443695000000000 | 0           | 2022-02-09T21:57:29.064Z | 2022-02-09T21:57:29.064Z | {}                                                                       |
-| evt_QJtL4x6701tFhKia | dev_mHH1Cp4gPybCPR8y | 1645047149000000000 | 0           | 2022-02-16T21:35:07.352Z | 2022-02-16T21:35:07.352Z | {"happy":"valley"}                                                       |
-| evt_kRIWfP2GgjCbLejp | dev_Wm1gvryKJmREqnVT | 1645483936331000000 | 17000000000 | 2022-02-21T23:19:10.521Z | 2022-02-21T23:19:10.521Z | {"calibration":"camera"}                                                 |
-| evt_J69qtmDyKtWmYZTb | dev_mHH1Cp4gPybCPR8y | 1645554501000000000 | 0           | 2022-02-23T18:28:50.228Z | 2022-02-23T18:28:50.228Z | {"color":"green","user":"adrian"}                                        |
-| evt_N6doUtPYh8i7iZxf | dev_jCuXYeFwCkZowpHs | 1646147056000000000 | 23000000000 | 2022-03-04T15:04:31.546Z | 2022-03-04T15:04:31.546Z | {"a":"13"}                                                               |
-| evt_idMGJImlICYP4dcy | dev_mHH1Cp4gPybCPR8y | 1646248453000000000 | 60          | 2022-03-02T19:14:39.117Z | 2022-03-02T19:14:39.117Z | {"requires-labeling":"true"}                                             |
+$ foxglove events list
+|          ID          |      DEVICE ID       |            START            |             END             |        CREATED AT        |        UPDATED AT        |           METADATA           |
+|----------------------|----------------------|-----------------------------|-----------------------------|--------------------------|--------------------------|------------------------------|
+| evt_N6doUtPYh8i7iZxf | dev_jCuXYeFwCkZowpHs | 2023-04-19T13:22:44.194041Z | 2023-04-19T13:22:44.194041Z | 2023-04-19T13:22:44.263Z | 2023-04-19T13:22:44.263Z | {}                           |
+| evt_idMGJImlICYP4dcy | dev_mHH1Cp4gPybCPR8y | 2023-04-19T13:26:37.030302Z | 2023-04-19T13:26:37.030302Z | 2023-04-19T13:26:37.080Z | 2023-04-19T13:26:37.080Z | {"requires-labeling":"true"} |
 ```
 
-For adding events, see `foxglove beta events add -h`.
+For adding events, see `foxglove events add -h`.
 
 #### Querying data
 ```

--- a/foxglove/cmd/beta_events.go
+++ b/foxglove/cmd/beta_events.go
@@ -20,6 +20,7 @@ func newBetaAddEventCommand(params *baseParams) *cobra.Command {
 		Use:   "add",
 		Short: "Add an event",
 		Run: func(cmd *cobra.Command, args []string) {
+			printDeprecation()
 			client := console.NewRemoteFoxgloveClient(
 				*params.baseURL, *params.clientID,
 				viper.GetString("bearer_token"),
@@ -72,6 +73,7 @@ func newBetaListEventsCommand(params *baseParams) *cobra.Command {
 		Use:   "list",
 		Short: "List events",
 		Run: func(cmd *cobra.Command, args []string) {
+			printDeprecation()
 			client := console.NewRemoteFoxgloveClient(
 				*params.baseURL, *params.clientID,
 				viper.GetString("bearer_token"),
@@ -110,4 +112,8 @@ func newBetaListEventsCommand(params *baseParams) *cobra.Command {
 	eventsListCmd.PersistentFlags().StringVarP(&value, "value", "", "", "return events with matching metadata values")
 	AddFormatFlag(eventsListCmd, &format)
 	return eventsListCmd
+}
+
+func printDeprecation() {
+	fmt.Fprintln(os.Stderr, "[Warning] this command is deprecated and will be removed in a future version. Use `foxglove events`.")
 }

--- a/foxglove/cmd/beta_events.go
+++ b/foxglove/cmd/beta_events.go
@@ -36,6 +36,7 @@ func newBetaAddEventCommand(params *baseParams) *cobra.Command {
 				}
 				metadata[parts[0]] = parts[1]
 			}
+			//nolint:staticcheck
 			response, err := client.BetaCreateEvent(console.BetaCreateEventRequest{
 				DeviceID:      deviceID,
 				DeviceName:    deviceName,
@@ -93,6 +94,7 @@ func newBetaListEventsCommand(params *baseParams) *cobra.Command {
 					Key:        key,
 					Value:      value,
 				},
+				//nolint:staticcheck
 				client.BetaEvents,
 				format,
 			)

--- a/foxglove/cmd/beta_events.go
+++ b/foxglove/cmd/beta_events.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func newBetaAddEventCommand(params *baseParams) *cobra.Command {
+	var deviceID string
+	var deviceName string
+	var timestamp string
+	var durationNanos string
+	var keyvals []string
+	addEventCmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add an event",
+		Run: func(cmd *cobra.Command, args []string) {
+			client := console.NewRemoteFoxgloveClient(
+				*params.baseURL, *params.clientID,
+				viper.GetString("bearer_token"),
+				params.userAgent,
+			)
+
+			metadata := make(map[string]string)
+			for _, kv := range keyvals {
+				parts := strings.FieldsFunc(kv, func(c rune) bool { return c == ':' })
+				if len(parts) != 2 {
+					fmt.Fprintf(os.Stderr, "Invalid key/value pair: %s\n", kv)
+					os.Exit(1)
+				}
+				metadata[parts[0]] = parts[1]
+			}
+			response, err := client.BetaCreateEvent(console.BetaCreateEventRequest{
+				DeviceID:      deviceID,
+				DeviceName:    deviceName,
+				Timestamp:     timestamp,
+				DurationNanos: durationNanos,
+				Metadata:      metadata,
+			})
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to add event: %s\n", err)
+				os.Exit(1)
+			}
+			fmt.Fprintf(os.Stderr, "Created event: %s\n", response.ID)
+		},
+	}
+	addEventCmd.PersistentFlags().StringVarP(&deviceID, "device-id", "", "", "Device ID")
+	addEventCmd.PersistentFlags().StringVarP(&timestamp, "timestamp", "", "", "Timestamp of event (RFC3339 format)")
+	addEventCmd.PersistentFlags().StringVarP(&durationNanos, "duration-nanos", "", "", "Duration of event in nanoseconds")
+	addEventCmd.PersistentFlags().StringArrayVarP(&keyvals, "metadata", "m", []string{}, "Metadata colon-separated key value pair. Multiple may be specified.")
+	return addEventCmd
+}
+
+func newBetaListEventsCommand(params *baseParams) *cobra.Command {
+	var format string
+	var deviceID string
+	var deviceName string
+	var sortBy string
+	var sortOrder string
+	var limit int
+	var offset int
+	var start string
+	var end string
+	var key string
+	var value string
+	eventsListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List events",
+		Run: func(cmd *cobra.Command, args []string) {
+			client := console.NewRemoteFoxgloveClient(
+				*params.baseURL, *params.clientID,
+				viper.GetString("bearer_token"),
+				params.userAgent,
+			)
+			err := renderList(
+				os.Stdout,
+				&console.BetaEventsRequest{
+					DeviceID:   deviceID,
+					DeviceName: deviceName,
+					SortBy:     sortBy,
+					SortOrder:  sortOrder,
+					Limit:      limit,
+					Offset:     offset,
+					Start:      start,
+					End:        end,
+					Key:        key,
+					Value:      value,
+				},
+				client.BetaEvents,
+				format,
+			)
+			if err != nil {
+				fatalf("Failed to list events: %s\n", err)
+			}
+		},
+	}
+	eventsListCmd.InheritedFlags()
+	eventsListCmd.PersistentFlags().StringVarP(&deviceID, "device-id", "", "", "Device ID")
+	eventsListCmd.PersistentFlags().StringVarP(&deviceName, "device-name", "", "", "name of device")
+	eventsListCmd.PersistentFlags().StringVarP(&sortBy, "sort-by", "", "", "name of sort column")
+	eventsListCmd.PersistentFlags().StringVarP(&sortOrder, "sort-order", "", "asc", "sort order")
+	eventsListCmd.PersistentFlags().IntVarP(&limit, "limit", "", 100, "limit")
+	eventsListCmd.PersistentFlags().IntVarP(&offset, "offset", "", 0, "offset")
+	eventsListCmd.PersistentFlags().StringVarP(&key, "key", "", "", "return events with matching metadata keys")
+	eventsListCmd.PersistentFlags().StringVarP(&value, "value", "", "", "return events with matching metadata values")
+	AddFormatFlag(eventsListCmd, &format)
+	return eventsListCmd
+}

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -12,9 +12,8 @@ import (
 
 func newAddEventCommand(params *baseParams) *cobra.Command {
 	var deviceID string
-	var deviceName string
-	var timestamp string
-	var durationNanos string
+	var start string
+	var end string
 	var keyvals []string
 	addEventCmd := &cobra.Command{
 		Use:   "add",
@@ -36,11 +35,10 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 				metadata[parts[0]] = parts[1]
 			}
 			response, err := client.CreateEvent(console.CreateEventRequest{
-				DeviceID:      deviceID,
-				DeviceName:    deviceName,
-				Timestamp:     timestamp,
-				DurationNanos: durationNanos,
-				Metadata:      metadata,
+				DeviceID: deviceID,
+				Start:    start,
+				End:      end,
+				Metadata: metadata,
 			})
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to add event: %s\n", err)
@@ -50,8 +48,8 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 		},
 	}
 	addEventCmd.PersistentFlags().StringVarP(&deviceID, "device-id", "", "", "Device ID")
-	addEventCmd.PersistentFlags().StringVarP(&timestamp, "timestamp", "", "", "Timestamp of event (RFC3339 format)")
-	addEventCmd.PersistentFlags().StringVarP(&durationNanos, "duration-nanos", "", "", "Duration of event in nanoseconds")
+	addEventCmd.PersistentFlags().StringVarP(&start, "start", "", "", "Start of event, RFC 3339 date-time format")
+	addEventCmd.PersistentFlags().StringVarP(&end, "end", "", "", "End of event (inclusive), RFC 3339 date-time format")
 	addEventCmd.PersistentFlags().StringArrayVarP(&keyvals, "metadata", "m", []string{}, "Metadata colon-separated key value pair. Multiple may be specified.")
 	return addEventCmd
 }
@@ -59,15 +57,13 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 func newListEventsCommand(params *baseParams) *cobra.Command {
 	var format string
 	var deviceID string
-	var deviceName string
 	var sortBy string
 	var sortOrder string
 	var limit int
 	var offset int
 	var start string
 	var end string
-	var key string
-	var value string
+	var query string
 	eventsListCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List events",
@@ -80,16 +76,14 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 			err := renderList(
 				os.Stdout,
 				&console.EventsRequest{
-					DeviceID:   deviceID,
-					DeviceName: deviceName,
-					SortBy:     sortBy,
-					SortOrder:  sortOrder,
-					Limit:      limit,
-					Offset:     offset,
-					Start:      start,
-					End:        end,
-					Key:        key,
-					Value:      value,
+					DeviceID:  deviceID,
+					SortBy:    sortBy,
+					SortOrder: sortOrder,
+					Limit:     limit,
+					Offset:    offset,
+					Start:     start,
+					End:       end,
+					Query:     query,
 				},
 				client.Events,
 				format,
@@ -101,13 +95,11 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 	}
 	eventsListCmd.InheritedFlags()
 	eventsListCmd.PersistentFlags().StringVarP(&deviceID, "device-id", "", "", "Device ID")
-	eventsListCmd.PersistentFlags().StringVarP(&deviceName, "device-name", "", "", "name of device")
 	eventsListCmd.PersistentFlags().StringVarP(&sortBy, "sort-by", "", "", "name of sort column")
 	eventsListCmd.PersistentFlags().StringVarP(&sortOrder, "sort-order", "", "asc", "sort order")
 	eventsListCmd.PersistentFlags().IntVarP(&limit, "limit", "", 100, "limit")
 	eventsListCmd.PersistentFlags().IntVarP(&offset, "offset", "", 0, "offset")
-	eventsListCmd.PersistentFlags().StringVarP(&key, "key", "", "", "return events with matching metadata keys")
-	eventsListCmd.PersistentFlags().StringVarP(&value, "value", "", "", "return events with matching metadata values")
+	eventsListCmd.PersistentFlags().StringVarP(&query, "query", "", "", "Filter by metadata with keyword or \"$key:$value\"")
 	AddFormatFlag(eventsListCmd, &format)
 	return eventsListCmd
 }

--- a/foxglove/cmd/root.go
+++ b/foxglove/cmd/root.go
@@ -68,10 +68,6 @@ func Execute(version string) {
 		Use:   "data",
 		Short: "Data access and management",
 	}
-	betaCmd := &cobra.Command{
-		Use:   "beta",
-		Short: "Experimental features",
-	}
 	importsCmd := &cobra.Command{
 		Use:   "imports",
 		Short: "Query and modify data imports",
@@ -141,7 +137,6 @@ func Execute(version string) {
 	authCmd.AddCommand(configureAPIKey)
 	importsCmd.AddCommand(newListImportsCommand(params), addImportCmd)
 	coverageCmd.AddCommand(newListCoverageCommand(params))
-	betaCmd.AddCommand(eventsCmd)
 	dataCmd.AddCommand(
 		exportCmd,
 		importsCmd,
@@ -154,7 +149,7 @@ func Execute(version string) {
 	extensionsCmd.AddCommand(newPublishExtensionCommand(params))
 	extensionsCmd.AddCommand(newUnpublishExtensionCommand(params))
 
-	rootCmd.AddCommand(authCmd, dataCmd, newVersionCommand(version), devicesCmd, betaCmd, extensionsCmd)
+	rootCmd.AddCommand(authCmd, dataCmd, newVersionCommand(version), devicesCmd, eventsCmd, extensionsCmd)
 
 	cobra.CheckErr(rootCmd.Execute())
 }

--- a/foxglove/cmd/root.go
+++ b/foxglove/cmd/root.go
@@ -68,6 +68,10 @@ func Execute(version string) {
 		Use:   "data",
 		Short: "Data access and management",
 	}
+	betaCmd := &cobra.Command{
+		Use:   "beta",
+		Short: "Experimental features",
+	}
 	importsCmd := &cobra.Command{
 		Use:   "imports",
 		Short: "Query and modify data imports",
@@ -79,6 +83,10 @@ func Execute(version string) {
 	eventsCmd := &cobra.Command{
 		Use:   "events",
 		Short: "List and manage events",
+	}
+	betaEventsCmd := &cobra.Command{
+		Use:   "events",
+		Short: "List and manage events (deprecated; use `foxglove events`)",
 	}
 	coverageCmd := &cobra.Command{
 		Use:   "coverage",
@@ -149,7 +157,11 @@ func Execute(version string) {
 	extensionsCmd.AddCommand(newPublishExtensionCommand(params))
 	extensionsCmd.AddCommand(newUnpublishExtensionCommand(params))
 
-	rootCmd.AddCommand(authCmd, dataCmd, newVersionCommand(version), devicesCmd, eventsCmd, extensionsCmd)
+	betaEventsCmd.AddCommand(newBetaAddEventCommand(params))
+	betaEventsCmd.AddCommand(newBetaListEventsCommand(params))
+	betaCmd.AddCommand(betaEventsCmd)
+
+	rootCmd.AddCommand(authCmd, dataCmd, newVersionCommand(version), devicesCmd, betaCmd, extensionsCmd, eventsCmd)
 
 	cobra.CheckErr(rootCmd.Execute())
 }

--- a/foxglove/console/api.go
+++ b/foxglove/console/api.go
@@ -150,47 +150,45 @@ func (r ImportsResponse) Headers() []string {
 }
 
 type EventsRequest struct {
-	DeviceID   string `json:"deviceId" form:"deviceId,omitempty"`
-	DeviceName string `json:"deviceName" form:"deviceName,omitempty"`
-	SortBy     string `json:"sortBy" form:"sortBy,omitempty"`
-	SortOrder  string `json:"sortOrder" form:"sortOrder,omitempty"`
-	Limit      int    `json:"limit" form:"limit,omitempty"`
-	Offset     int    `json:"offset" form:"offset,omitempty"`
-	Start      string `json:"start" form:"start,omitempty"`
-	End        string `json:"end" form:"end,omitempty"`
-	Key        string `json:"key" form:"key,omitempty"`
-	Value      string `json:"value" form:"value,omitempty"`
+	DeviceID  string `json:"deviceId" form:"deviceId,omitempty"`
+	SortBy    string `json:"sortBy" form:"sortBy,omitempty"`
+	SortOrder string `json:"sortOrder" form:"sortOrder,omitempty"`
+	Limit     int    `json:"limit" form:"limit,omitempty"`
+	Offset    int    `json:"offset" form:"offset,omitempty"`
+	Start     string `json:"start" form:"start,omitempty"`
+	End       string `json:"end" form:"end,omitempty"`
+	Query     string `json:"key" form:"query,omitempty"`
 }
 
-type EventsResponse struct {
-	ID             string            `json:"id"`
-	DeviceID       string            `json:"deviceId"`
-	TimestampNanos string            `json:"timestampNanos"`
-	DurationNanos  string            `json:"durationNanos"`
-	Metadata       map[string]string `json:"metadata"`
-	CreatedAt      string            `json:"createdAt"`
-	UpdatedAt      string            `json:"updatedAt"`
+type EventResponseItem struct {
+	ID        string            `json:"id"`
+	DeviceID  string            `json:"deviceId"`
+	Start     string            `json:"start"`
+	End       string            `json:"end"`
+	Metadata  map[string]string `json:"metadata"`
+	CreatedAt string            `json:"createdAt"`
+	UpdatedAt string            `json:"updatedAt"`
 }
 
-func (r EventsResponse) Fields() []string {
+func (r EventResponseItem) Fields() []string {
 	metadata, _ := json.Marshal(r.Metadata)
 	return []string{
 		r.ID,
 		r.DeviceID,
-		r.TimestampNanos,
-		r.DurationNanos,
+		r.Start,
+		r.End,
 		r.CreatedAt,
 		r.UpdatedAt,
 		string(metadata),
 	}
 }
 
-func (r EventsResponse) Headers() []string {
+func (r EventResponseItem) Headers() []string {
 	return []string{
 		"ID",
 		"Device ID",
-		"Timestamp",
-		"Duration",
+		"Start",
+		"End",
 		"Created At",
 		"Updated At",
 		"Metadata",
@@ -246,22 +244,13 @@ type CreateDeviceResponse struct {
 }
 
 type CreateEventRequest struct {
-	DeviceID      string            `json:"deviceId"`
-	DeviceName    string            `json:"deviceName"`
-	Timestamp     string            `json:"timestamp"`
-	DurationNanos string            `json:"durationNanos"`
-	Metadata      map[string]string `json:"metadata"`
+	DeviceID string            `json:"deviceId"`
+	Start    string            `json:"start"`
+	End      string            `json:"end"`
+	Metadata map[string]string `json:"metadata"`
 }
 
-type CreateEventResponse struct {
-	ID             string            `json:"id"`
-	DeviceID       string            `json:"deviceId"`
-	TimestampNanos string            `json:"timestampNanos"`
-	DurationNanos  string            `json:"durationNanos"`
-	Metadata       map[string]string `json:"metadata"`
-	CreatedAt      string            `json:"createdAt"`
-	UpdatedAt      string            `json:"updatedAt"`
-}
+type CreateEventResponse = EventResponseItem
 
 type ExtensionsRequest struct{}
 

--- a/foxglove/console/client.go
+++ b/foxglove/console/client.go
@@ -234,6 +234,12 @@ func (c *FoxgloveClient) CreateEvent(req CreateEventRequest) (resp CreateEventRe
 	return resp, err
 }
 
+// Deprecated: use CreateEvent
+func (c *FoxgloveClient) BetaCreateEvent(req BetaCreateEventRequest) (resp BetaCreateEventResponse, err error) {
+	err = c.post("/beta/device-events", req, &resp)
+	return resp, err
+}
+
 // UploadExtension sends the contents of a reader to the extension-upload endpoint.
 // This endpoint  can be used to create an extension, or update with a new version.
 // Extension & version information is parsed from the extension's package.json.
@@ -295,6 +301,12 @@ func (c *FoxgloveClient) Devices(req DevicesRequest) (resp []DevicesResponse, er
 
 func (c *FoxgloveClient) Events(req *EventsRequest) (resp []EventResponseItem, err error) {
 	err = c.get("/v1/events", req, &resp)
+	return resp, err
+}
+
+// Deprecated: use Events
+func (c *FoxgloveClient) BetaEvents(req *BetaEventsRequest) (resp []BetaEventsResponse, err error) {
+	err = c.get("/beta/device-events", req, &resp)
 	return resp, err
 }
 

--- a/foxglove/console/client.go
+++ b/foxglove/console/client.go
@@ -230,7 +230,7 @@ func (c *FoxgloveClient) CreateDevice(req CreateDeviceRequest) (resp CreateDevic
 }
 
 func (c *FoxgloveClient) CreateEvent(req CreateEventRequest) (resp CreateEventResponse, err error) {
-	err = c.post("/beta/device-events", req, &resp)
+	err = c.post("/v1/events", req, &resp)
 	return resp, err
 }
 
@@ -293,8 +293,8 @@ func (c *FoxgloveClient) Devices(req DevicesRequest) (resp []DevicesResponse, er
 	return resp, err
 }
 
-func (c *FoxgloveClient) Events(req *EventsRequest) (resp []EventsResponse, err error) {
-	err = c.get("/beta/device-events", req, &resp)
+func (c *FoxgloveClient) Events(req *EventsRequest) (resp []EventResponseItem, err error) {
+	err = c.get("/v1/events", req, &resp)
 	return resp, err
 }
 

--- a/foxglove/console/deprecated_api.go
+++ b/foxglove/console/deprecated_api.go
@@ -1,0 +1,69 @@
+package console
+
+import "encoding/json"
+
+type BetaEventsRequest struct {
+	DeviceID   string `json:"deviceId" form:"deviceId,omitempty"`
+	DeviceName string `json:"deviceName" form:"deviceName,omitempty"`
+	SortBy     string `json:"sortBy" form:"sortBy,omitempty"`
+	SortOrder  string `json:"sortOrder" form:"sortOrder,omitempty"`
+	Limit      int    `json:"limit" form:"limit,omitempty"`
+	Offset     int    `json:"offset" form:"offset,omitempty"`
+	Start      string `json:"start" form:"start,omitempty"`
+	End        string `json:"end" form:"end,omitempty"`
+	Key        string `json:"key" form:"key,omitempty"`
+	Value      string `json:"value" form:"value,omitempty"`
+}
+
+type BetaEventsResponse struct {
+	ID             string            `json:"id"`
+	DeviceID       string            `json:"deviceId"`
+	TimestampNanos string            `json:"timestampNanos"`
+	DurationNanos  string            `json:"durationNanos"`
+	Metadata       map[string]string `json:"metadata"`
+	CreatedAt      string            `json:"createdAt"`
+	UpdatedAt      string            `json:"updatedAt"`
+}
+
+func (r BetaEventsResponse) Fields() []string {
+	metadata, _ := json.Marshal(r.Metadata)
+	return []string{
+		r.ID,
+		r.DeviceID,
+		r.TimestampNanos,
+		r.DurationNanos,
+		r.CreatedAt,
+		r.UpdatedAt,
+		string(metadata),
+	}
+}
+
+func (r BetaEventsResponse) Headers() []string {
+	return []string{
+		"ID",
+		"Device ID",
+		"Timestamp",
+		"Duration",
+		"Created At",
+		"Updated At",
+		"Metadata",
+	}
+}
+
+type BetaCreateEventRequest struct {
+	DeviceID      string            `json:"deviceId"`
+	DeviceName    string            `json:"deviceName"`
+	Timestamp     string            `json:"timestamp"`
+	DurationNanos string            `json:"durationNanos"`
+	Metadata      map[string]string `json:"metadata"`
+}
+
+type BetaCreateEventResponse struct {
+	ID             string            `json:"id"`
+	DeviceID       string            `json:"deviceId"`
+	TimestampNanos string            `json:"timestampNanos"`
+	DurationNanos  string            `json:"durationNanos"`
+	Metadata       map[string]string `json:"metadata"`
+	CreatedAt      string            `json:"createdAt"`
+	UpdatedAt      string            `json:"updatedAt"`
+}


### PR DESCRIPTION
This adds new top-level `events` commands which use v1 of the API. The beta events commands are extant but now print a deprecation warning to stderr. I did not spend time removing duplication between the two; the old code exists in new files which is easily removed once we're ready to.

Reference docs: https://foxglove.dev/docs/api#tag/Events