### PR TITLE
Clean up generated test files

### DIFF
--- a/foxglove/cmd/export_test.go
+++ b/foxglove/cmd/export_test.go
@@ -197,6 +197,11 @@ func TestDoExport(t *testing.T) {
 			"user-agent",
 		)
 		assert.Nil(t, err)
+
+		t.Cleanup(func() {
+			os.Remove("output.mcap")
+		})
+
 		err = doExport(
 			ctx,
 			"output.mcap",

--- a/foxglove/util/ros/bag_writer_test.go
+++ b/foxglove/util/ros/bag_writer_test.go
@@ -20,6 +20,11 @@ func TestProduceSimpleOutputBag(t *testing.T) {
 			"basic bag",
 		},
 	}
+
+	t.Cleanup(func() {
+		os.Remove("test.bag")
+	})
+
 	for _, c := range cases {
 		t.Run(c.assertion, func(t *testing.T) {
 			f, err := os.Create("test.bag")


### PR DESCRIPTION
This removes files created by tests.

We may also want to generate these test files outside of the source directory, but I've left that alone for now.