### PR TITLE
Support listing events by device name

### DIFF
--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -57,6 +57,7 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 func newListEventsCommand(params *baseParams) *cobra.Command {
 	var format string
 	var deviceID string
+	var deviceName string
 	var sortBy string
 	var sortOrder string
 	var limit int
@@ -76,14 +77,15 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 			err := renderList(
 				os.Stdout,
 				&console.EventsRequest{
-					DeviceID:  deviceID,
-					SortBy:    sortBy,
-					SortOrder: sortOrder,
-					Limit:     limit,
-					Offset:    offset,
-					Start:     start,
-					End:       end,
-					Query:     query,
+					DeviceID:   deviceID,
+					DeviceName: deviceName,
+					SortBy:     sortBy,
+					SortOrder:  sortOrder,
+					Limit:      limit,
+					Offset:     offset,
+					Start:      start,
+					End:        end,
+					Query:      query,
 				},
 				client.Events,
 				format,
@@ -95,6 +97,7 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 	}
 	eventsListCmd.InheritedFlags()
 	eventsListCmd.PersistentFlags().StringVarP(&deviceID, "device-id", "", "", "Device ID")
+	eventsListCmd.PersistentFlags().StringVarP(&deviceName, "device-name", "", "", "Device name")
 	eventsListCmd.PersistentFlags().StringVarP(&sortBy, "sort-by", "", "", "name of sort column")
 	eventsListCmd.PersistentFlags().StringVarP(&sortOrder, "sort-order", "", "asc", "sort order")
 	eventsListCmd.PersistentFlags().IntVarP(&limit, "limit", "", 100, "limit")

--- a/foxglove/console/api.go
+++ b/foxglove/console/api.go
@@ -283,19 +283,20 @@ func (r ImportsResponse) Headers() []string {
 }
 
 type EventsRequest struct {
-	DeviceID  string `json:"deviceId" form:"deviceId,omitempty"`
-	SortBy    string `json:"sortBy" form:"sortBy,omitempty"`
-	SortOrder string `json:"sortOrder" form:"sortOrder,omitempty"`
-	Limit     int    `json:"limit" form:"limit,omitempty"`
-	Offset    int    `json:"offset" form:"offset,omitempty"`
-	Start     string `json:"start" form:"start,omitempty"`
-	End       string `json:"end" form:"end,omitempty"`
-	Query     string `json:"key" form:"query,omitempty"`
+	DeviceID   string `json:"device.id" form:"device.id,omitempty"`
+	DeviceName string `json:"device.name" form:"device.name,omitempty"`
+	SortBy     string `json:"sortBy" form:"sortBy,omitempty"`
+	SortOrder  string `json:"sortOrder" form:"sortOrder,omitempty"`
+	Limit      int    `json:"limit" form:"limit,omitempty"`
+	Offset     int    `json:"offset" form:"offset,omitempty"`
+	Start      string `json:"start" form:"start,omitempty"`
+	End        string `json:"end" form:"end,omitempty"`
+	Query      string `json:"key" form:"query,omitempty"`
 }
 
 type EventResponseItem struct {
 	ID        string            `json:"id"`
-	DeviceID  string            `json:"deviceId"`
+	Device    DeviceSummary     `json:"device"`
 	Start     string            `json:"start"`
 	End       string            `json:"end"`
 	Metadata  map[string]string `json:"metadata"`
@@ -307,7 +308,8 @@ func (r EventResponseItem) Fields() []string {
 	metadata, _ := json.Marshal(r.Metadata)
 	return []string{
 		r.ID,
-		r.DeviceID,
+		r.Device.ID,
+		r.Device.Name,
 		r.Start,
 		r.End,
 		r.CreatedAt,
@@ -320,6 +322,7 @@ func (r EventResponseItem) Headers() []string {
 	return []string{
 		"ID",
 		"Device ID",
+		"Device Name",
 		"Start",
 		"End",
 		"Created At",


### PR DESCRIPTION
Adds a --device-name parameter to "foxglove events list", and returns the device name in the response.