### PR TITLE
Support device name on the coverage endpoint

### DIFF
--- a/foxglove/cmd/coverage.go
+++ b/foxglove/cmd/coverage.go
@@ -2,16 +2,23 @@ package cmd
 
 import (
 	"os"
+	"time"
 
 	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/relvacode/iso8601"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 func newListCoverageCommand(params *baseParams) *cobra.Command {
+	var deviceName string
+	var deviceID string
 	var format string
 	var start string
 	var end string
+	var tolerance int
+	var recordingID string
+	var includeEdgeRecordings bool
 	coverageListCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List coverage ranges",
@@ -21,11 +28,30 @@ func newListCoverageCommand(params *baseParams) *cobra.Command {
 				viper.GetString("bearer_token"),
 				params.userAgent,
 			)
+			var startTime, endTime string
+			if start != "" {
+				parsed, err := iso8601.ParseString(start)
+				if err != nil {
+					dief("failed to parse start time: %s", err)
+				}
+				startTime = parsed.Format(time.RFC3339)
+			}
+			if end != "" {
+				parsed, err := iso8601.ParseString(end)
+				if err != nil {
+					dief("failed to parse end time: %s", err)
+				}
+				endTime = parsed.Format(time.RFC3339)
+			}
+
 			err := renderList(
 				os.Stdout,
 				&console.CoverageRequest{
-					Start: start,
-					End:   end,
+					DeviceID:    deviceID,
+					DeviceName:  deviceName,
+					Start:       startTime,
+					End:         endTime,
+					RecordingID: recordingID,
 				},
 				client.Coverage,
 				format,
@@ -36,6 +62,13 @@ func newListCoverageCommand(params *baseParams) *cobra.Command {
 		},
 	}
 	coverageListCmd.InheritedFlags()
+	coverageListCmd.PersistentFlags().StringVarP(&deviceID, "device-id", "", "", "Device ID")
+	coverageListCmd.PersistentFlags().StringVarP(&deviceName, "device-name", "", "", "Device name")
+	coverageListCmd.PersistentFlags().StringVarP(&recordingID, "recording-id", "", "", "Recording ID")
+	coverageListCmd.PersistentFlags().IntVarP(&tolerance, "tolerance", "", 0,
+		"Number of seconds by which ranges must be separated to be considered distinct")
+
+	coverageListCmd.PersistentFlags().BoolVarP(&includeEdgeRecordings, "include-edge-recordings", "", false, "Include edge recordings")
 	coverageListCmd.PersistentFlags().StringVarP(&start, "start", "", "", "start of coverage time range")
 	coverageListCmd.PersistentFlags().StringVarP(&end, "end", "", "", "end of coverage time range")
 	AddFormatFlag(coverageListCmd, &format)

--- a/foxglove/cmd/coverage.go
+++ b/foxglove/cmd/coverage.go
@@ -28,6 +28,8 @@ func newListCoverageCommand(params *baseParams) *cobra.Command {
 				viper.GetString("bearer_token"),
 				params.userAgent,
 			)
+			// We accept ISO8601, which is a little more lenient than the API. Here
+			// we convert to RFC3339.
 			var startTime, endTime string
 			if start != "" {
 				parsed, err := iso8601.ParseString(start)
@@ -47,11 +49,13 @@ func newListCoverageCommand(params *baseParams) *cobra.Command {
 			err := renderList(
 				os.Stdout,
 				&console.CoverageRequest{
-					DeviceID:    deviceID,
-					DeviceName:  deviceName,
-					Start:       startTime,
-					End:         endTime,
-					RecordingID: recordingID,
+					DeviceID:              deviceID,
+					DeviceName:            deviceName,
+					Start:                 startTime,
+					End:                   endTime,
+					RecordingID:           recordingID,
+					Tolerance:             tolerance,
+					IncludeEdgeRecordings: includeEdgeRecordings,
 				},
 				client.Coverage,
 				format,
@@ -69,8 +73,8 @@ func newListCoverageCommand(params *baseParams) *cobra.Command {
 		"Number of seconds by which ranges must be separated to be considered distinct")
 
 	coverageListCmd.PersistentFlags().BoolVarP(&includeEdgeRecordings, "include-edge-recordings", "", false, "Include edge recordings")
-	coverageListCmd.PersistentFlags().StringVarP(&start, "start", "", "", "start of coverage time range")
-	coverageListCmd.PersistentFlags().StringVarP(&end, "end", "", "", "end of coverage time range")
+	coverageListCmd.PersistentFlags().StringVarP(&start, "start", "", "", "start of coverage time range (ISO8601)")
+	coverageListCmd.PersistentFlags().StringVarP(&end, "end", "", "", "end of coverage time range (ISO8601)")
 	AddFormatFlag(coverageListCmd, &format)
 	return coverageListCmd
 }

--- a/foxglove/console/api.go
+++ b/foxglove/console/api.go
@@ -329,28 +329,39 @@ func (r EventResponseItem) Headers() []string {
 }
 
 type CoverageRequest struct {
-	Start string `json:"start" form:"start,omitempty"`
-	End   string `json:"end" form:"end,omitempty"`
+	Tolerance             int    `json:"tolerance" form:"tolerance,omitempty"`
+	RecordingID           string `json:"recordingId" form:"recordingId,omitempty"`
+	IncludeEdgeRecordings bool   `json:"includeEdgeRecordings" form:"includeEdgeRecordings,omitempty"`
+	DeviceID              string `json:"device.id" form:"device.id,omitempty"`
+	DeviceName            string `json:"device.name" form:"device.name,omitempty"`
+	Start                 string `json:"start" form:"start,omitempty"`
+	End                   string `json:"end" form:"end,omitempty"`
 }
 type CoverageResponse struct {
-	DeviceID string `json:"deviceId"`
-	Start    string `json:"start"`
-	End      string `json:"end"`
+	DeviceID string        `json:"deviceId"`
+	Device   DeviceSummary `json:"device"`
+	Start    string        `json:"start"`
+	End      string        `json:"end"`
+	Status   string        `json:"status"`
 }
 
 func (r CoverageResponse) Headers() []string {
 	return []string{
 		"Device ID",
+		"Device Name",
 		"Start",
 		"End",
+		"Status",
 	}
 }
 
 func (r CoverageResponse) Fields() []string {
 	return []string{
-		r.DeviceID,
+		r.Device.ID,
+		r.Device.Name,
 		r.Start,
 		r.End,
+		r.Status,
 	}
 }
 


### PR DESCRIPTION
Supports querying coverage by device name and seeing device name in the results. Also brings the set of request parameters/response fields in line with the coverage response.