### PR TITLE
Accept ISO8601 on the export command

### DIFF
--- a/foxglove/cmd/coverage.go
+++ b/foxglove/cmd/coverage.go
@@ -2,10 +2,8 @@ package cmd
 
 import (
 	"os"
-	"time"
 
 	"github.com/foxglove/foxglove-cli/foxglove/console"
-	"github.com/relvacode/iso8601"
 	"github.com/spf13/cobra"
 )
 
@@ -29,23 +27,15 @@ func newListCoverageCommand(params *baseParams) *cobra.Command {
 			)
 			// We accept ISO8601, which is a little more lenient than the API. Here
 			// we convert to RFC3339.
-			var startTime, endTime string
-			if start != "" {
-				parsed, err := iso8601.ParseString(start)
-				if err != nil {
-					dief("failed to parse start time: %s", err)
-				}
-				startTime = parsed.Format(time.RFC3339)
+			startTime, err := maybeConvertToRFC3339(start)
+			if err != nil {
+				dief("failed to parse start time: %s", err)
 			}
-			if end != "" {
-				parsed, err := iso8601.ParseString(end)
-				if err != nil {
-					dief("failed to parse end time: %s", err)
-				}
-				endTime = parsed.Format(time.RFC3339)
+			endTime, err := maybeConvertToRFC3339(end)
+			if err != nil {
+				dief("failed to parse end time: %s", err)
 			}
-
-			err := renderList(
+			err = renderList(
 				os.Stdout,
 				&console.CoverageRequest{
 					DeviceID:              deviceID,

--- a/foxglove/cmd/export.go
+++ b/foxglove/cmd/export.go
@@ -887,12 +887,20 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 		Use:   "export",
 		Short: "Export a data selection from foxglove data platform",
 		Run: func(cmd *cobra.Command, args []string) {
+			startTime, err := maybeConvertToRFC3339(start)
+			if err != nil {
+				dief("failed to parse start time: %s", err)
+			}
+			endTime, err := maybeConvertToRFC3339(end)
+			if err != nil {
+				dief("failed to parse end time: %s", err)
+			}
 			request, err := createStreamRequest(
 				importID,
 				deviceID,
 				deviceName,
-				start,
-				end,
+				startTime,
+				endTime,
 				outputFormat,
 				topicList,
 			)
@@ -937,8 +945,8 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 	exportCmd.PersistentFlags().StringVarP(&deviceName, "device-name", "", "", "device name")
 	exportCmd.PersistentFlags().StringVarP(&outputFile, "output-file", "o", "", "output file")
 	exportCmd.PersistentFlags().StringVarP(&importID, "import-id", "", "", "import ID")
-	exportCmd.PersistentFlags().StringVarP(&start, "start", "", "", "start time (RFC3339 timestamp)")
-	exportCmd.PersistentFlags().StringVarP(&end, "end", "", "", "end time (RFC3339 timestamp")
+	exportCmd.PersistentFlags().StringVarP(&start, "start", "", "", "start time (ISO8601 timestamp)")
+	exportCmd.PersistentFlags().StringVarP(&end, "end", "", "", "end time (ISO8601 timestamp")
 	exportCmd.PersistentFlags().StringVarP(&outputFormat, "output-format", "", "mcap0", "output format (mcap0, bag1, or json)")
 	exportCmd.PersistentFlags().StringVarP(&topicList, "topics", "", "", "comma separated list of topics")
 	AddDeviceAutocompletion(exportCmd, params)

--- a/foxglove/cmd/imports.go
+++ b/foxglove/cmd/imports.go
@@ -25,14 +25,30 @@ func newListImportsCommand(params *baseParams) *cobra.Command {
 				params.token,
 				params.userAgent,
 			)
-			err := renderList(
+			startTime, err := maybeConvertToRFC3339(start)
+			if err != nil {
+				dief("failed to parse start time: %s", err)
+			}
+			endTime, err := maybeConvertToRFC3339(end)
+			if err != nil {
+				dief("failed to parse end time: %s", err)
+			}
+			dataStartTime, err := maybeConvertToRFC3339(dataStart)
+			if err != nil {
+				dief("failed to parse data start time: %s", err)
+			}
+			dataEndTime, err := maybeConvertToRFC3339(dataEnd)
+			if err != nil {
+				dief("failed to parse data end time: %s", err)
+			}
+			err = renderList(
 				os.Stdout,
 				&console.ImportsRequest{
 					DeviceID:       deviceID,
-					Start:          start,
-					End:            end,
-					DataStart:      dataStart,
-					DataEnd:        dataEnd,
+					Start:          startTime,
+					End:            endTime,
+					DataStart:      dataStartTime,
+					DataEnd:        dataEndTime,
 					IncludeDeleted: includeDeleted,
 				},
 				client.Imports,
@@ -46,10 +62,10 @@ func newListImportsCommand(params *baseParams) *cobra.Command {
 	}
 	importsListCmd.InheritedFlags()
 	importsListCmd.PersistentFlags().StringVarP(&deviceID, "device-id", "", "", "Device ID")
-	importsListCmd.PersistentFlags().StringVarP(&start, "start", "", "", "start of import time range")
-	importsListCmd.PersistentFlags().StringVarP(&end, "end", "", "", "end of import time range")
-	importsListCmd.PersistentFlags().StringVarP(&dataStart, "data-start", "", "", "start of data time range")
-	importsListCmd.PersistentFlags().StringVarP(&dataEnd, "data-end", "", "", "end of data time range")
+	importsListCmd.PersistentFlags().StringVarP(&start, "start", "", "", "start of import time range (ISO8601)")
+	importsListCmd.PersistentFlags().StringVarP(&end, "end", "", "", "end of import time range (ISO8601)")
+	importsListCmd.PersistentFlags().StringVarP(&dataStart, "data-start", "", "", "start of data time range (ISO8601)")
+	importsListCmd.PersistentFlags().StringVarP(&dataEnd, "data-end", "", "", "end of data time range (ISO8601)")
 	importsListCmd.PersistentFlags().BoolVarP(&includeDeleted, "include-deleted", "", false, "end of data time range")
 	AddFormatFlag(importsListCmd, &format)
 	return importsListCmd

--- a/foxglove/cmd/recordings.go
+++ b/foxglove/cmd/recordings.go
@@ -3,10 +3,8 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/foxglove/foxglove-cli/foxglove/console"
-	"github.com/relvacode/iso8601"
 	"github.com/spf13/cobra"
 )
 
@@ -29,22 +27,13 @@ func newListRecordingsCommand(params *baseParams) *cobra.Command {
 				params.token,
 				params.userAgent,
 			)
-			var err error
-			var startTime string
-			var endTime string
-			if start != "" {
-				parsed, err := iso8601.ParseString(start)
-				if err != nil {
-					dief("failed to parse start time: %s", err)
-				}
-				startTime = parsed.Format(time.RFC3339)
+			startTime, err := maybeConvertToRFC3339(start)
+			if err != nil {
+				dief("failed to parse start time: %s", err)
 			}
-			if end != "" {
-				parsed, err := iso8601.ParseString(end)
-				if err != nil {
-					dief("failed to parse end time: %s", err)
-				}
-				endTime = parsed.Format(time.RFC3339)
+			endTime, err := maybeConvertToRFC3339(end)
+			if err != nil {
+				dief("failed to parse end time: %s", err)
 			}
 			err = renderList(
 				os.Stdout,

--- a/foxglove/cmd/utils.go
+++ b/foxglove/cmd/utils.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/foxglove/foxglove-cli/foxglove/console"
 	"github.com/foxglove/mcap/go/mcap"
 	"github.com/olekukonko/tablewriter"
+	"github.com/relvacode/iso8601"
 	"github.com/spf13/cobra"
 )
 
@@ -205,4 +207,18 @@ func promptForInput(prompt string) string {
 	var value string
 	fmt.Scanln(&value)
 	return value
+}
+
+// maybeConvertToRFC3339 converts an ISO8601 timestamp to RFC3339, if an input
+// timestamp is supplied. If the input is empty, it returns an empty string and
+// no error.
+func maybeConvertToRFC3339(timestamp string) (string, error) {
+	if timestamp == "" {
+		return "", nil
+	}
+	parsed, err := iso8601.ParseString(timestamp)
+	if err != nil {
+		return "", err
+	}
+	return parsed.Format(time.RFC3339), nil
 }

--- a/foxglove/cmd/utils_test.go
+++ b/foxglove/cmd/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/foxglove/mcap/go/mcap"
+	"github.com/relvacode/iso8601"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -110,6 +111,50 @@ func TestRenderList(t *testing.T) {
 			buf := &bytes.Buffer{}
 			err := renderList(buf, nil, func(any) ([]TestRecord, error) { return records, nil }, c.format)
 			assert.Nil(t, err)
+		})
+	}
+}
+
+func TestMaybeConvertToRFC3339(t *testing.T) {
+	cases := []struct {
+		assertion string
+		input     string
+		output    string
+		err       error
+	}{
+		{
+			"accepts RFC3339",
+			"2021-01-01T00:00:00Z",
+			"2021-01-01T00:00:00Z",
+			nil,
+		},
+		{
+			"accepts ISO8601",
+			"2021-01-01",
+			"2021-01-01T00:00:00Z",
+			nil,
+		},
+		{
+			"handles empty input",
+			"",
+			"",
+			nil,
+		},
+		{
+			"handles invalid input",
+			"not a date",
+			"",
+			&iso8601.UnexpectedCharacterError{
+				Character: 'n',
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.assertion, func(t *testing.T) {
+			output, err := maybeConvertToRFC3339(c.input)
+			assert.Equal(t, c.output, output)
+			assert.Equal(t, c.err, err)
 		})
 	}
 }


### PR DESCRIPTION
This matches the behavior of some more recently added subcommands.