### PR TITLE
Handle wide table outputs

### DIFF
--- a/foxglove/cmd/utils.go
+++ b/foxglove/cmd/utils.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/foxglove/foxglove-cli/foxglove/console"
+	tw "github.com/foxglove/foxglove-cli/foxglove/util/tablewriter"
 	"github.com/foxglove/mcap/go/mcap"
-	"github.com/olekukonko/tablewriter"
 	"github.com/relvacode/iso8601"
 	"github.com/spf13/cobra"
 )
@@ -91,7 +91,15 @@ func renderList[RequestType console.Request, ResponseType console.Record](
 	}
 	switch format {
 	case "table":
-		renderTable(w, records)
+		if len(records) == 0 {
+			fmt.Println("No records found")
+			return nil
+		}
+		data := [][]string{}
+		for _, record := range records {
+			data = append(data, record.Fields())
+		}
+		tw.PrintTable(w, records[0].Headers(), data)
 	case "json":
 		err := renderJSON(w, records)
 		if err != nil {
@@ -106,29 +114,6 @@ func renderList[RequestType console.Request, ResponseType console.Record](
 		return fmt.Errorf("unsupported format %s", format)
 	}
 	return nil
-}
-
-func renderTable[RecordType console.Record](w io.Writer, records []RecordType) {
-	table := tablewriter.NewWriter(w)
-	if len(records) == 0 {
-		return
-	}
-	headers := records[0].Headers()
-	table.SetHeader(headers)
-	table.SetBorders(tablewriter.Border{
-		Left:   true,
-		Top:    false,
-		Right:  true,
-		Bottom: false,
-	})
-	table.SetAlignment(tablewriter.ALIGN_LEFT)
-	table.SetCenterSeparator("|")
-	data := [][]string{}
-	for _, record := range records {
-		data = append(data, record.Fields())
-	}
-	table.AppendBulk(data)
-	table.Render()
 }
 
 func renderJSON[RecordType console.Record](w io.Writer, records []RecordType) error {

--- a/foxglove/cmd/utils_test.go
+++ b/foxglove/cmd/utils_test.go
@@ -74,16 +74,6 @@ func TestRenderJSON(t *testing.T) {
 			"\n", ""))
 }
 
-func TestRenderTable(t *testing.T) {
-	records := []TestRecord{
-		{A: "a", B: "b"},
-		{A: "c", B: "d"},
-	}
-	buf := &bytes.Buffer{}
-	renderTable(buf, records)
-	assert.Equal(t, "| A | B |\n|---|---|\n| a | b |\n| c | d |\n", buf.String())
-}
-
 func TestRenderList(t *testing.T) {
 	records := []TestRecord{
 		{A: "a", B: "b"},

--- a/foxglove/console/api.go
+++ b/foxglove/console/api.go
@@ -184,7 +184,7 @@ type RecordingsResponse struct {
 	End          string           `json:"end"`
 	ImportStatus string           `json:"importStatus"`
 	Site         SiteSummary      `json:"site"`
-	EdgeSite     SiteSummary      `json:"edgeSite"`
+	EdgeSite     *SiteSummary     `json:"edgeSite"`
 	Device       DeviceSummary    `json:"device"`
 	Metadata     []MetadataRecord `json:"metadata"`
 }

--- a/foxglove/util/tablewriter/tablewriter.go
+++ b/foxglove/util/tablewriter/tablewriter.go
@@ -1,0 +1,163 @@
+package tablewriter
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func computeHotdogCellWidths(headers []string, data [][]string) (int, []int) {
+	cellWidths := make([]int, len(headers))
+	for i, header := range headers {
+		headerWidth := len(header) + 4 // pad two spaces each side
+		cellWidths[i] = headerWidth
+	}
+	for _, row := range data {
+		for i, column := range row {
+			columnWidth := len(column) + 2 // pad one space per side
+			if cellWidths[i] < columnWidth {
+				cellWidths[i] = columnWidth
+			}
+		}
+	}
+
+	// size the cells so the headers can be center-spaced
+	for i, header := range headers {
+		if (cellWidths[i]-len(header))%2 == 1 {
+			cellWidths[i] += 1
+		}
+	}
+
+	tableWidth := len(headers) + 1
+	for _, width := range cellWidths {
+		tableWidth += width
+	}
+
+	return tableWidth, cellWidths
+}
+
+/*
+printHotDog outputs a table of records formatted like this:
+|          ID          |         Name         |      Created At      |      Updated At      |
+|----------------------|----------------------|----------------------|----------------------|
+| dev_qOo9LfqjfymSj50y | hilti-handheld       | 2023-06-01T11:37:55Z | 2023-06-01T11:37:55Z |
+| dev_kmJaeAdpSyLkqORp | my-new-device        | 2023-05-26T16:40:38Z | 2023-05-26T16:40:38Z |
+*/
+func printHotDog(w io.Writer, headers []string, data [][]string) {
+	_, cellWidths := computeHotdogCellWidths(headers, data)
+
+	// write the headers
+	fmt.Fprintf(w, "|")
+	for i, header := range headers {
+		padding := (cellWidths[i] - len(header)) / 2
+		fmt.Fprintf(w, "%s%s%s|", strings.Repeat(" ", padding), header, strings.Repeat(" ", padding))
+	}
+	fmt.Fprintln(w)
+
+	// write the separator
+	fmt.Fprintf(w, "|")
+	for _, width := range cellWidths {
+		fmt.Fprint(w, strings.Repeat("-", width))
+		fmt.Fprintf(w, "|")
+	}
+	fmt.Fprintln(w)
+
+	// write the data
+	for _, row := range data {
+		fmt.Fprint(w, "|")
+		for i, col := range row {
+			fmt.Fprintf(w, " %s%s|", col, strings.Repeat(" ", cellWidths[i]-len(col)-1))
+		}
+		fmt.Fprintln(w)
+	}
+}
+
+/*
+printHamburger outputs a series of records formatted like this:
+
+	-[ RECORD 17 ]+-----------------------------------
+	ID            | dev_zZFmSJfwI4OX4HJq
+	Name          | roman-gps-mcap
+	Created At    | 2021-11-17T18:23:49Z
+	Updated At    | 2021-11-17T18:23:49Z
+*/
+func printHamburger(w io.Writer, termwidth int, headers []string, data [][]string) {
+	var maxHeaderWidth int
+	var maxRecordWidth int
+
+	// compute the max header width
+	for _, header := range headers {
+		if len(header) > maxHeaderWidth {
+			maxHeaderWidth = len(header)
+		}
+	}
+
+	// compute the max record width
+	for _, row := range data {
+		for _, col := range row {
+			if len(col) > maxRecordWidth {
+				maxRecordWidth = len(col)
+			}
+		}
+	}
+
+	// ensure there is sufficient room to accommodate the highest record header
+	// required.
+	longestRecordHeader := fmt.Sprintf("-[ RECORD %d ]", len(data)+1)
+	if len(longestRecordHeader) > maxHeaderWidth {
+		maxHeaderWidth = len(longestRecordHeader)
+	}
+
+	// rightExtent is how far to extend  the dashes after the +. If there's
+	// sufficient room, set it 15 spaces farther than the max record width. If
+	// this would cause a wrap, set it to fill the term width.
+	dashesRightExtent := maxRecordWidth + 15
+	maxAllowedExtent := termwidth - maxHeaderWidth - 1
+	if dashesRightExtent > maxAllowedExtent {
+		dashesRightExtent = maxAllowedExtent
+	}
+	rightDashes := strings.Repeat("-", dashesRightExtent)
+
+	// print the records
+	for i, row := range data {
+		recordHeader := fmt.Sprintf("-[ RECORD %d ]", i+1)
+		header := fmt.Sprintf(
+			"%s%s+%s",
+			recordHeader,
+			strings.Repeat("-", maxHeaderWidth-len(recordHeader)),
+			rightDashes,
+		)
+		fmt.Fprintln(w, header)
+		for j, col := range row {
+			fmt.Fprintf(w, "%-*s| %-*s", maxHeaderWidth, headers[j], dashesRightExtent-1, col)
+			fmt.Fprintln(w)
+		}
+	}
+}
+
+func getTermWidth() int {
+	cmd := exec.Command("stty", "size")
+	cmd.Stdin = os.Stdin
+	out, err := cmd.Output()
+	if err != nil {
+		return 80
+	}
+	var rows, cols int
+	_, err = fmt.Sscanf(string(out), "%d %d", &rows, &cols)
+	if err != nil {
+		return 80
+	}
+	return cols
+}
+
+func PrintTable(w io.Writer, headers []string, data [][]string) {
+	termWidth := getTermWidth()
+	tableWidth, _ := computeHotdogCellWidths(headers, data)
+	if termWidth < tableWidth {
+		printHamburger(w, termWidth, headers, data)
+		return
+	}
+	printHotDog(w, headers, data)
+}


### PR DESCRIPTION
Improves the table output format to handle wide outputs. When a columnar output will require more terminal space than available, switch to a hamburger-style output like

    -[ RECORD 16 ]+-----------------------------------
    ID            | dev_x8wU5YSImVfjoSbD
    Name          | Devicey
    Created At    | 2022-02-09T22:10:43Z
    Updated At    | 2022-02-09T22:10:43Z
    -[ RECORD 17 ]+-----------------------------------
    ID            | dev_zZFmSJfwI4OX4HJq
    Name          | roman-gps-mcap
    Created At    | 2021-11-17T18:23:49Z
    Updated At    | 2021-11-17T18:23:49Z
    -[ RECORD 18 ]+-----------------------------------
    ID            | dev_mHH1Cp4gPybCPR8y
    Name          | Adrian's Robot
    Created At    | 2021-10-28T17:20:55Z
    Updated At    | 2021-10-28T17:20:55Z
