### PR TITLE
Deprecate serial number for devices

### DIFF
--- a/foxglove/cmd/devices.go
+++ b/foxglove/cmd/devices.go
@@ -47,9 +47,13 @@ func newAddDeviceCommand(params *baseParams) *cobra.Command {
 				params.token,
 				params.userAgent,
 			)
+
+			if serialNumber != "" {
+				fmt.Fprintf(os.Stderr, "Warning: serial-number is deprecated and will be removed in the next release\n")
+			}
+
 			resp, err := client.CreateDevice(console.CreateDeviceRequest{
-				Name:         name,
-				SerialNumber: serialNumber,
+				Name: name,
 			})
 			if err != nil {
 				fatalf("Failed to create device: %s\n", err)
@@ -59,6 +63,6 @@ func newAddDeviceCommand(params *baseParams) *cobra.Command {
 	}
 	addDeviceCmd.InheritedFlags()
 	addDeviceCmd.PersistentFlags().StringVarP(&name, "name", "", "", "name of the device")
-	addDeviceCmd.PersistentFlags().StringVarP(&serialNumber, "serial-number", "", "", "device serial number")
+	addDeviceCmd.PersistentFlags().StringVarP(&serialNumber, "serial-number", "", "", "Deprecated. Value will be ignored.")
 	return addDeviceCmd
 }

--- a/foxglove/console/api.go
+++ b/foxglove/console/api.go
@@ -384,13 +384,11 @@ type ErrorResponse struct {
 }
 
 type CreateDeviceRequest struct {
-	Name         string `json:"name"`
-	SerialNumber string `json:"serialNumber,omitempty"`
+	Name string `json:"name"`
 }
 type CreateDeviceResponse struct {
-	ID           string  `json:"id"`
-	Name         string  `json:"name"`
-	SerialNumber *string `json:"serialNumber"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 type CreateEventRequest struct {


### PR DESCRIPTION
This deprecates the serial-number arg for creating devices. This property is no longer used by the API.