### PR TITLE
Support custom properties when creating a device

### DIFF
--- a/foxglove/cmd/devices.go
+++ b/foxglove/cmd/devices.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/foxglove/foxglove-cli/foxglove/console"
 	"github.com/spf13/cobra"
@@ -38,6 +39,7 @@ func newListDevicesCommand(params *baseParams) *cobra.Command {
 func newAddDeviceCommand(params *baseParams) *cobra.Command {
 	var name string
 	var serialNumber string
+	var propertyPairs []string
 	addDeviceCmd := &cobra.Command{
 		Use:   "add",
 		Short: "Add a device for your organization",
@@ -52,8 +54,10 @@ func newAddDeviceCommand(params *baseParams) *cobra.Command {
 				fmt.Fprintf(os.Stderr, "Warning: serial-number is deprecated and will be removed in the next release\n")
 			}
 
+			propertyVals := propertyMap(propertyPairs)
 			resp, err := client.CreateDevice(console.CreateDeviceRequest{
-				Name: name,
+				Name:       name,
+				Properties: propertyVals,
 			})
 			if err != nil {
 				fatalf("Failed to create device: %s\n", err)
@@ -64,5 +68,27 @@ func newAddDeviceCommand(params *baseParams) *cobra.Command {
 	addDeviceCmd.InheritedFlags()
 	addDeviceCmd.PersistentFlags().StringVarP(&name, "name", "", "", "name of the device")
 	addDeviceCmd.PersistentFlags().StringVarP(&serialNumber, "serial-number", "", "", "Deprecated. Value will be ignored.")
+	addDeviceCmd.PersistentFlags().StringArrayVarP(&propertyPairs, "property", "p", []string{}, "Custom property colon-separated key value pair. Multiple may be specified.")
 	return addDeviceCmd
+}
+
+//	type PropertyValue interface {
+//		 string | int64 | float64 | bool
+//	}
+//
+// todo: need to consider value types and return generic
+// https://stackoverflow.com/questions/71047848/how-to-assign-or-return-generic-t-that-is-constrained-by-union
+// https://go.dev/play/p/JVBEZwCXRMW
+// func properties[V PropertyValue](propertyPairs []string) map[string]V {
+func propertyMap(propertyPairs []string) map[string]interface{} {
+	properties := make(map[string]interface{})
+	for _, kv := range propertyPairs {
+		parts := strings.FieldsFunc(kv, func(c rune) bool { return c == ':' })
+		if len(parts) != 2 {
+			fmt.Fprintf(os.Stderr, "Invalid key/value pair: %s\n", kv)
+			os.Exit(1)
+		}
+		properties[parts[0]] = parts[1]
+	}
+	return properties
 }

--- a/foxglove/cmd/devices.go
+++ b/foxglove/cmd/devices.go
@@ -3,11 +3,19 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strings"
+	"strconv"
 
 	"github.com/foxglove/foxglove-cli/foxglove/console"
 	"github.com/spf13/cobra"
 )
+
+type PropertyDefinition struct {
+	Key        string
+	ValueType  string
+	EnumValues map[string]struct{}
+}
+
+type OrgCustomProperties map[string]PropertyDefinition
 
 func newListDevicesCommand(params *baseParams) *cobra.Command {
 	var format string
@@ -54,10 +62,14 @@ func newAddDeviceCommand(params *baseParams) *cobra.Command {
 				fmt.Fprintf(os.Stderr, "Warning: serial-number is deprecated and will be removed in the next release\n")
 			}
 
-			propertyVals := propertyMap(propertyPairs)
+			properties, err := deviceProperties(propertyPairs, client)
+			if err != nil {
+				fatalf("Failed to create device: %s\n", err)
+			}
+
 			resp, err := client.CreateDevice(console.CreateDeviceRequest{
 				Name:       name,
-				Properties: propertyVals,
+				Properties: properties,
 			})
 			if err != nil {
 				fatalf("Failed to create device: %s\n", err)
@@ -72,23 +84,92 @@ func newAddDeviceCommand(params *baseParams) *cobra.Command {
 	return addDeviceCmd
 }
 
-//	type PropertyValue interface {
-//		 string | int64 | float64 | bool
-//	}
-//
-// todo: need to consider value types and return generic
-// https://stackoverflow.com/questions/71047848/how-to-assign-or-return-generic-t-that-is-constrained-by-union
-// https://go.dev/play/p/JVBEZwCXRMW
-// func properties[V PropertyValue](propertyPairs []string) map[string]V {
-func propertyMap(propertyPairs []string) map[string]interface{} {
+// Validate CLI properties input & convert to args for a device request.
+// This requires downloading the available properties for the org.
+func deviceProperties(propertyPairs []string, client *console.FoxgloveClient) (map[string]interface{}, error) {
+	if len(propertyPairs) == 0 {
+		return nil, nil
+	}
+
+	propertyMap, err := fetchAvailableProperties(client)
+	if err != nil {
+		return nil, fmt.Errorf("%s", err)
+	}
+
 	properties := make(map[string]interface{})
 	for _, kv := range propertyPairs {
-		parts := strings.FieldsFunc(kv, func(c rune) bool { return c == ':' })
-		if len(parts) != 2 {
-			fmt.Fprintf(os.Stderr, "Invalid key/value pair: %s\n", kv)
-			os.Exit(1)
+		key, val, err := splitPair(kv, ':')
+		if err != nil {
+			return nil, err
 		}
-		properties[parts[0]] = parts[1]
+
+		property, hasKey := propertyMap[key]
+		if !hasKey {
+			return nil, fmt.Errorf("unknown key: %s", key)
+		}
+
+		switch property.ValueType {
+		case "string":
+			properties[key] = val
+		case "number":
+			properties[key], err = strconv.ParseFloat(val, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for number: %s", val)
+			}
+		case "enum":
+			_, hasVal := property.EnumValues[val]
+			if !hasVal {
+				return nil, fmt.Errorf("invalid enum value: %s", val)
+			}
+			properties[key] = val
+		case "boolean":
+			properties[key], err = strconv.ParseBool(val)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for boolean: %s", val)
+			}
+		default:
+			return nil, fmt.Errorf("unsupported type: %s", property.ValueType)
+		}
 	}
-	return properties
+	return properties, nil
+}
+
+// Reduce response items into a map keyed by the property's key
+func propertyDefinitions(props []console.CustomPropertiesResponseItem) (map[string]console.CustomPropertiesResponseItem, error) {
+	properties := make(map[string]console.CustomPropertiesResponseItem)
+	for _, prop := range props {
+		properties[prop.Key] = prop
+	}
+	return properties, nil
+}
+
+// Download device custom properties and convert to a lookup map
+func fetchAvailableProperties(client *console.FoxgloveClient) (OrgCustomProperties, error) {
+	propertiesResp, err := client.DeviceCustomProperties(console.CustomPropertiesRequest{
+		ResourceType: "device",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to load custom properties: %s\n", err)
+	}
+
+	properties := make(map[string]PropertyDefinition)
+	for _, prop := range propertiesResp {
+		properties[prop.Key] = PropertyDefinition{
+			Key:        prop.Key,
+			ValueType:  prop.ValueType,
+			EnumValues: valueSet(prop.Values),
+		}
+	}
+
+	return properties, nil
+}
+
+// Reduce a slice of strings into a map with empty values
+func valueSet(values []string) map[string]struct{} {
+	var present struct{}
+	valSet := make(map[string]struct{})
+	for _, val := range values {
+		valSet[val] = present
+	}
+	return valSet
 }

--- a/foxglove/cmd/devices.go
+++ b/foxglove/cmd/devices.go
@@ -3,19 +3,11 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strconv"
 
 	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/util"
 	"github.com/spf13/cobra"
 )
-
-type PropertyDefinition struct {
-	Key        string
-	ValueType  string
-	EnumValues map[string]struct{}
-}
-
-type OrgCustomProperties map[string]PropertyDefinition
 
 func newListDevicesCommand(params *baseParams) *cobra.Command {
 	var format string
@@ -62,7 +54,7 @@ func newAddDeviceCommand(params *baseParams) *cobra.Command {
 				fmt.Fprintf(os.Stderr, "Warning: serial-number is deprecated and will be removed in the next release\n")
 			}
 
-			properties, err := deviceProperties(propertyPairs, client)
+			properties, err := util.DeviceProperties(propertyPairs, client)
 			if err != nil {
 				fatalf("Failed to create device: %s\n", err)
 			}
@@ -82,94 +74,4 @@ func newAddDeviceCommand(params *baseParams) *cobra.Command {
 	addDeviceCmd.PersistentFlags().StringVarP(&serialNumber, "serial-number", "", "", "Deprecated. Value will be ignored.")
 	addDeviceCmd.PersistentFlags().StringArrayVarP(&propertyPairs, "property", "p", []string{}, "Custom property colon-separated key value pair. Multiple may be specified.")
 	return addDeviceCmd
-}
-
-// Validate CLI properties input & convert to args for a device request.
-// This requires downloading the available properties for the org.
-func deviceProperties(propertyPairs []string, client *console.FoxgloveClient) (map[string]interface{}, error) {
-	if len(propertyPairs) == 0 {
-		return nil, nil
-	}
-
-	propertyMap, err := fetchAvailableProperties(client)
-	if err != nil {
-		return nil, fmt.Errorf("%s", err)
-	}
-
-	properties := make(map[string]interface{})
-	for _, kv := range propertyPairs {
-		key, val, err := splitPair(kv, ':')
-		if err != nil {
-			return nil, err
-		}
-
-		property, hasKey := propertyMap[key]
-		if !hasKey {
-			return nil, fmt.Errorf("unknown key: %s", key)
-		}
-
-		switch property.ValueType {
-		case "string":
-			properties[key] = val
-		case "number":
-			properties[key], err = strconv.ParseFloat(val, 64)
-			if err != nil {
-				return nil, fmt.Errorf("invalid value for number: %s", val)
-			}
-		case "enum":
-			_, hasVal := property.EnumValues[val]
-			if !hasVal {
-				return nil, fmt.Errorf("invalid enum value: %s", val)
-			}
-			properties[key] = val
-		case "boolean":
-			properties[key], err = strconv.ParseBool(val)
-			if err != nil {
-				return nil, fmt.Errorf("invalid value for boolean: %s", val)
-			}
-		default:
-			return nil, fmt.Errorf("unsupported type: %s", property.ValueType)
-		}
-	}
-	return properties, nil
-}
-
-// Reduce response items into a map keyed by the property's key
-func propertyDefinitions(props []console.CustomPropertiesResponseItem) (map[string]console.CustomPropertiesResponseItem, error) {
-	properties := make(map[string]console.CustomPropertiesResponseItem)
-	for _, prop := range props {
-		properties[prop.Key] = prop
-	}
-	return properties, nil
-}
-
-// Download device custom properties and convert to a lookup map
-func fetchAvailableProperties(client *console.FoxgloveClient) (OrgCustomProperties, error) {
-	propertiesResp, err := client.DeviceCustomProperties(console.CustomPropertiesRequest{
-		ResourceType: "device",
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to load custom properties: %s\n", err)
-	}
-
-	properties := make(map[string]PropertyDefinition)
-	for _, prop := range propertiesResp {
-		properties[prop.Key] = PropertyDefinition{
-			Key:        prop.Key,
-			ValueType:  prop.ValueType,
-			EnumValues: valueSet(prop.Values),
-		}
-	}
-
-	return properties, nil
-}
-
-// Reduce a slice of strings into a map with empty values
-func valueSet(values []string) map[string]struct{} {
-	var present struct{}
-	valSet := make(map[string]struct{})
-	for _, val := range values {
-		valSet[val] = present
-	}
-	return valSet
 }

--- a/foxglove/cmd/devices_test.go
+++ b/foxglove/cmd/devices_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddDeviceCommand(t *testing.T) {
+	ctx := context.Background()
+	sv, err := console.NewMockServer(ctx)
+	assert.Nil(t, err)
+
+	t.Run("creates a device", func(t *testing.T) {
+		client := console.NewMockAuthedClient(t, sv.BaseURL())
+		dev, err := client.CreateDevice(console.CreateDeviceRequest{
+			Name:       "new-device",
+			Properties: map[string]interface{}{"key": "val"},
+		})
+		assert.Nil(t, err)
+
+		assert.Contains(t, sv.RegisteredDevices(), console.DevicesResponse{
+			ID:         dev.ID,
+			Name:       dev.Name,
+			Properties: dev.Properties,
+		})
+	})
+}

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/foxglove/foxglove-cli/foxglove/console"
 	"github.com/spf13/cobra"
@@ -26,12 +25,12 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 
 			metadata := make(map[string]string)
 			for _, kv := range keyvals {
-				parts := strings.FieldsFunc(kv, func(c rune) bool { return c == ':' })
-				if len(parts) != 2 {
+				key, val, err := splitPair(kv, ':')
+				if err != nil {
 					fmt.Fprintf(os.Stderr, "Invalid key/value pair: %s\n", kv)
 					os.Exit(1)
 				}
-				metadata[parts[0]] = parts[1]
+				metadata[key] = val
 			}
 			response, err := client.CreateEvent(console.CreateEventRequest{
 				DeviceID: deviceID,

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/util"
 	"github.com/spf13/cobra"
 )
 
@@ -25,7 +26,7 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 
 			metadata := make(map[string]string)
 			for _, kv := range keyvals {
-				key, val, err := splitPair(kv, ':')
+				key, val, err := util.SplitPair(kv, ':')
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Invalid key/value pair: %s\n", kv)
 					os.Exit(1)

--- a/foxglove/cmd/extensions_test.go
+++ b/foxglove/cmd/extensions_test.go
@@ -46,7 +46,7 @@ func TestUnpublishExtensionCommand(t *testing.T) {
 	t.Run("returns ok if deleted", func(t *testing.T) {
 		sv, err := console.NewMockServer(ctx)
 		assert.Nil(t, err)
-		client := newAuthedClient(t, sv.BaseURL())
+		client := console.NewMockAuthedClient(t, sv.BaseURL())
 		err = executeExtensionDelete(
 			client,
 			sv.ValidExtensionId(),
@@ -56,28 +56,11 @@ func TestUnpublishExtensionCommand(t *testing.T) {
 	t.Run("does not error if extension not found", func(t *testing.T) {
 		sv, err := console.NewMockServer(ctx)
 		assert.Nil(t, err)
-		client := newAuthedClient(t, sv.BaseURL())
+		client := console.NewMockAuthedClient(t, sv.BaseURL())
 		err = executeExtensionDelete(
 			client,
 			"nonexistent-extension-id",
 		)
 		assert.Nil(t, err)
 	})
-}
-
-func newAuthedClient(t *testing.T, baseUrl string) *console.FoxgloveClient {
-	client := console.NewRemoteFoxgloveClient(
-		baseUrl,
-		"client",
-		"",
-		"user-agent",
-	)
-	token, err := client.SignIn("client-id")
-	assert.Nil(t, err)
-	return console.NewRemoteFoxgloveClient(
-		baseUrl,
-		"client",
-		token,
-		"user-agent",
-	)
 }

--- a/foxglove/cmd/utils.go
+++ b/foxglove/cmd/utils.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/foxglove/foxglove-cli/foxglove/console"
@@ -207,13 +206,4 @@ func maybeConvertToRFC3339(timestamp string) (string, error) {
 		return "", err
 	}
 	return parsed.Format(time.RFC3339), nil
-}
-
-// Split a key/value string on a given delimiter into a key/value pair
-func splitPair(kv string, delim rune) (key string, value string, err error) {
-	parts := strings.FieldsFunc(kv, func(c rune) bool { return c == delim })
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("invalid key/value pair: %s", kv)
-	}
-	return parts[0], parts[1], nil
 }

--- a/foxglove/cmd/utils.go
+++ b/foxglove/cmd/utils.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/foxglove/foxglove-cli/foxglove/console"
@@ -206,4 +207,13 @@ func maybeConvertToRFC3339(timestamp string) (string, error) {
 		return "", err
 	}
 	return parsed.Format(time.RFC3339), nil
+}
+
+// Split a key/value string on a given delimiter into a key/value pair
+func splitPair(kv string, delim rune) (key string, value string, err error) {
+	parts := strings.FieldsFunc(kv, func(c rune) bool { return c == delim })
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid key/value pair: %s", kv)
+	}
+	return parts[0], parts[1], nil
 }

--- a/foxglove/console/api.go
+++ b/foxglove/console/api.go
@@ -389,7 +389,7 @@ type ErrorResponse struct {
 
 type CreateDeviceRequest struct {
 	Name       string                 `json:"name"`
-	Properties map[string]interface{} `json:"properties"`
+	Properties map[string]interface{} `json:"properties,omitempty"`
 }
 
 type CreateDeviceResponse struct {
@@ -417,6 +417,18 @@ type ExtensionResponse struct {
 	Description   *string `json:"description"`
 	ActiveVersion *string `json:"activeVersion"`
 	Sha256Sum     *string `json:"sha256Sum"`
+}
+
+type CustomPropertiesRequest struct {
+	ResourceType string `json:"resourceType"`
+}
+
+type CustomPropertiesResponseItem struct {
+	Key          string   `json:"key"`
+	Label        string   `json:"label"`
+	ResourceType string   `json:"resourceType"`
+	ValueType    string   `json:"valueType"`
+	Values       []string `json:"values"`
 }
 
 func (r ExtensionResponse) Fields() []string {

--- a/foxglove/console/api.go
+++ b/foxglove/console/api.go
@@ -388,11 +388,14 @@ type ErrorResponse struct {
 }
 
 type CreateDeviceRequest struct {
-	Name string `json:"name"`
+	Name       string                 `json:"name"`
+	Properties map[string]interface{} `json:"properties"`
 }
+
 type CreateDeviceResponse struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID         string                 `json:"id"`
+	Name       string                 `json:"name"`
+	Properties map[string]interface{} `json:"properties"`
 }
 
 type CreateEventRequest struct {

--- a/foxglove/console/api.go
+++ b/foxglove/console/api.go
@@ -75,16 +75,19 @@ type DeviceCodeResponse struct {
 type DevicesRequest struct{}
 
 type DevicesResponse struct {
-	ID        string    `json:"id"`
-	Name      string    `json:"name"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	ID         string                 `json:"id"`
+	Name       string                 `json:"name"`
+	Properties map[string]interface{} `json:"properties"`
+	CreatedAt  time.Time              `json:"createdAt"`
+	UpdatedAt  time.Time              `json:"updatedAt"`
 }
 
 func (r DevicesResponse) Fields() []string {
+	properties, _ := json.Marshal(r.Properties)
 	return []string{
 		r.ID,
 		r.Name,
+		string(properties),
 		r.CreatedAt.Format(time.RFC3339),
 		r.UpdatedAt.Format(time.RFC3339),
 	}
@@ -94,6 +97,7 @@ func (r DevicesResponse) Headers() []string {
 	return []string{
 		"ID",
 		"Name",
+		"Custom Properties",
 		"Created At",
 		"Updated At",
 	}

--- a/foxglove/console/client.go
+++ b/foxglove/console/client.go
@@ -341,6 +341,11 @@ func (c *FoxgloveClient) Extensions(req ExtensionsRequest) (resp []ExtensionResp
 	return resp, err
 }
 
+func (c *FoxgloveClient) DeviceCustomProperties(req CustomPropertiesRequest) (resp []CustomPropertiesResponseItem, err error) {
+	err = c.get("/v1/custom-properties", req, &resp)
+	return resp, err
+}
+
 func (c *FoxgloveClient) Attachment(id string) (io.ReadCloser, error) {
 	res, err := c.authed.Get(c.baseurl + "/v1/recording-attachments/" + id + "/download")
 	if err != nil {

--- a/foxglove/console/mock_client.go
+++ b/foxglove/console/mock_client.go
@@ -1,0 +1,24 @@
+package console
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func NewMockAuthedClient(t *testing.T, baseUrl string) *FoxgloveClient {
+	client := NewRemoteFoxgloveClient(
+		baseUrl,
+		"client",
+		"",
+		"user-agent",
+	)
+	token, err := client.SignIn("client-id")
+	assert.Nil(t, err)
+	return NewRemoteFoxgloveClient(
+		baseUrl,
+		"client",
+		token,
+		"user-agent",
+	)
+}

--- a/foxglove/console/mock_service.go
+++ b/foxglove/console/mock_service.go
@@ -144,13 +144,7 @@ func (s *MockFoxgloveServer) upload(w http.ResponseWriter, r *http.Request) {
 func (s *MockFoxgloveServer) devices(w http.ResponseWriter, r *http.Request) {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
-	response := []CustomPropertiesResponseItem{
-		{Key: "str", ResourceType: "devices", Label: "", ValueType: "string"},
-		{Key: "num", ResourceType: "devices", Label: "", ValueType: "number"},
-		{Key: "bool", ResourceType: "devices", Label: "", ValueType: "boolean"},
-		{Key: "enum", ResourceType: "devices", Label: "", ValueType: "enum", Values: []string{"foo", "bar"}},
-	}
-	err := json.NewEncoder(w).Encode(response)
+	err := json.NewEncoder(w).Encode(s.registeredDevices)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 	}

--- a/foxglove/util/custom_properties.go
+++ b/foxglove/util/custom_properties.go
@@ -1,0 +1,97 @@
+package util
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/foxglove/foxglove-cli/foxglove/console"
+)
+
+type OrgCustomProperties map[string]PropertyDefinition
+
+type PropertyDefinition struct {
+	Key        string
+	ValueType  string
+	EnumValues map[string]struct{}
+}
+
+// Validate CLI properties input & convert to args for a device request.
+// This requires downloading the available properties for the org.
+func DeviceProperties(propertyPairs []string, client *console.FoxgloveClient) (map[string]interface{}, error) {
+	if len(propertyPairs) == 0 {
+		return nil, nil
+	}
+
+	propertyMap, err := fetchAvailableProperties(client)
+	if err != nil {
+		return nil, fmt.Errorf("%s", err)
+	}
+
+	properties := make(map[string]interface{})
+	for _, kv := range propertyPairs {
+		key, val, err := SplitPair(kv, ':')
+		if err != nil {
+			return nil, err
+		}
+
+		property, hasKey := propertyMap[key]
+		if !hasKey {
+			return nil, fmt.Errorf("unknown key: %s", key)
+		}
+
+		switch property.ValueType {
+		case "string":
+			properties[key] = val
+		case "number":
+			properties[key], err = strconv.ParseFloat(val, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for number: %s", val)
+			}
+		case "enum":
+			_, hasVal := property.EnumValues[val]
+			if !hasVal {
+				return nil, fmt.Errorf("invalid enum value: %s", val)
+			}
+			properties[key] = val
+		case "boolean":
+			properties[key], err = strconv.ParseBool(val)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for boolean: %s", val)
+			}
+		default:
+			return nil, fmt.Errorf("unsupported type: %s", property.ValueType)
+		}
+	}
+	return properties, nil
+}
+
+// Download device custom properties and convert to a lookup map
+func fetchAvailableProperties(client *console.FoxgloveClient) (OrgCustomProperties, error) {
+	propertiesResp, err := client.DeviceCustomProperties(console.CustomPropertiesRequest{
+		ResourceType: "device",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to load custom properties: %s\n", err)
+	}
+
+	properties := make(map[string]PropertyDefinition)
+	for _, prop := range propertiesResp {
+		properties[prop.Key] = PropertyDefinition{
+			Key:        prop.Key,
+			ValueType:  prop.ValueType,
+			EnumValues: valueSet(prop.Values),
+		}
+	}
+
+	return properties, nil
+}
+
+// Reduce a slice of strings into a map with empty values
+func valueSet(values []string) map[string]struct{} {
+	var present struct{}
+	valSet := make(map[string]struct{})
+	for _, val := range values {
+		valSet[val] = present
+	}
+	return valSet
+}

--- a/foxglove/util/custom_properties_test.go
+++ b/foxglove/util/custom_properties_test.go
@@ -1,0 +1,83 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeviceProperties(t *testing.T) {
+	ctx := context.Background()
+	sv, err := console.NewMockServer(ctx)
+	assert.Nil(t, err)
+	propertyOfType := func(valueType string) *console.CustomPropertiesResponseItem {
+		for _, prop := range sv.RegisteredProperties() {
+			if prop.ValueType == valueType {
+				return &prop
+			}
+		}
+		return nil
+	}
+
+	t.Run("returns error on unknown keys", func(t *testing.T) {
+		client := newAuthedClient(t, sv.BaseURL())
+
+		input := []string{"foo:bar"}
+		_, err = DeviceProperties(input, client)
+		assert.Equal(t, fmt.Errorf("unknown key: foo"), err)
+	})
+
+	t.Run("returns error for invalid value type", func(t *testing.T) {
+		client := newAuthedClient(t, sv.BaseURL())
+
+		numProp := propertyOfType("number")
+
+		input := []string{fmt.Sprintf("%s:foo", numProp.Key)}
+		_, err := DeviceProperties(input, client)
+		assert.Equal(t, err, fmt.Errorf("invalid value for number: foo"))
+	})
+
+	t.Run("converts values based on valueType", func(t *testing.T) {
+		client := newAuthedClient(t, sv.BaseURL())
+
+		strProp := propertyOfType("string")
+		numProp := propertyOfType("number")
+		boolProp := propertyOfType("boolean")
+		enumProp := propertyOfType("enum")
+
+		input := []string{
+			fmt.Sprintf("%s:bar", strProp.Key),
+			fmt.Sprintf("%s:true", boolProp.Key),
+			fmt.Sprintf("%s:1.5", numProp.Key),
+			fmt.Sprintf("%s:%s", enumProp.Key, enumProp.Values[0]),
+		}
+		properties, err := DeviceProperties(input, client)
+		assert.Nil(t, err)
+		assert.Equal(t, properties, map[string]interface{}{
+			strProp.Key:  "bar",
+			numProp.Key:  1.5,
+			boolProp.Key: true,
+			enumProp.Key: enumProp.Values[0],
+		})
+	})
+}
+
+func newAuthedClient(t *testing.T, baseUrl string) *console.FoxgloveClient {
+	client := console.NewRemoteFoxgloveClient(
+		baseUrl,
+		"client",
+		"",
+		"user-agent",
+	)
+	token, err := client.SignIn("client-id")
+	assert.Nil(t, err)
+	return console.NewRemoteFoxgloveClient(
+		baseUrl,
+		"client",
+		token,
+		"user-agent",
+	)
+}

--- a/foxglove/util/split_pair.go
+++ b/foxglove/util/split_pair.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Split a key/value string on a given delimiter into a pair
+func SplitPair(kv string, delim rune) (key string, value string, err error) {
+	parts := strings.FieldsFunc(kv, func(c rune) bool { return c == delim })
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid key/value pair: %s", kv)
+	}
+	return parts[0], parts[1], nil
+}


### PR DESCRIPTION
This adds support for custom properties when creating a device.

```
foxglove devices add --name newname --property key1:val1 --property k2:3 -p k3:true
```

`--property` (`-p`) may be specified multiple times — this is a similar UI to event metadata.

To support this, we make an additional request to fetch the org custom properties and use that to convert the value types.