### PR TITLE
Support device editing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           go-version: 1.20.x
       - name: install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.1
       - name: lint code
         run: make lint
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: install go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.20.x
       - name: install golangci-lint
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
       - name: lint code
@@ -26,7 +26,7 @@ jobs:
       - name: install go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.20.x
       - name: Checkout code
         uses: actions/checkout@v3
       - run: git lfs pull
@@ -77,7 +77,7 @@ jobs:
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.20.x
       - name: Setup environment
         run: ${{ matrix.setup }}
       - name: Build binary

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ page](https://github.com/foxglove/foxglove-cli/releases).
 
 #### Install from source
 Installation from source requires the following:
-* Go >= 1.18
+* Go >= 1.20
 
 To install from source, run
 

--- a/foxglove/cmd/devices_test.go
+++ b/foxglove/cmd/devices_test.go
@@ -28,3 +28,21 @@ func TestAddDeviceCommand(t *testing.T) {
 		})
 	})
 }
+
+func TestEditDeviceCommand(t *testing.T) {
+	ctx := context.Background()
+	sv, err := console.NewMockServer(ctx)
+	assert.Nil(t, err)
+
+	t.Run("creates a device", func(t *testing.T) {
+		client := console.NewMockAuthedClient(t, sv.BaseURL())
+		dev, err := client.EditDevice("test-device", console.CreateDeviceRequest{
+			Name:       "new-name",
+			Properties: map[string]interface{}{"key": "val"},
+		})
+		assert.Nil(t, err)
+
+		assert.Equal(t, dev.Name, "new-name")
+		assert.Equal(t, dev.Properties, map[string]interface{}{"key": "val"})
+	})
+}

--- a/foxglove/cmd/root.go
+++ b/foxglove/cmd/root.go
@@ -204,7 +204,7 @@ func Execute(version string) {
 		coverageCmd,
 		importShortcut,
 	)
-	devicesCmd.AddCommand(newListDevicesCommand(params), newAddDeviceCommand(params))
+	devicesCmd.AddCommand(newListDevicesCommand(params), newAddDeviceCommand(params), newEditDeviceCommand(params))
 	eventsCmd.AddCommand(newListEventsCommand(params), newAddEventCommand(params))
 	extensionsCmd.AddCommand(newListExtensionsCommand(params))
 	extensionsCmd.AddCommand(newPublishExtensionCommand(params))

--- a/foxglove/console/api.go
+++ b/foxglove/console/api.go
@@ -398,6 +398,13 @@ type CreateDeviceResponse struct {
 	Properties map[string]interface{} `json:"properties"`
 }
 
+type EditDeviceRequest struct {
+	Name       string                 `json:"name"`
+	Properties map[string]interface{} `json:"properties,omitempty"`
+}
+
+type EditDeviceResponse CreateDeviceResponse
+
 type CreateEventRequest struct {
 	DeviceID string            `json:"deviceId"`
 	Start    string            `json:"start"`

--- a/foxglove/go.mod
+++ b/foxglove/go.mod
@@ -1,6 +1,6 @@
 module github.com/foxglove/foxglove-cli/foxglove
 
-go 1.18
+go 1.20
 
 require (
 	github.com/ajg/form v1.5.1


### PR DESCRIPTION
This adds a device edit command.

```
foxglove devices edit {nameOrId} --name newname --property key1:val1 --property k2:3 -p k3:true
```

- `edit` is the command name, the counterpart to `add`
- `--name` specifies the new name
- `--property` (`-p`), which can be specified multiple times, is specified like event metadata

This depends on #113 for custom property support.

This also upgrades go to 1.20 and golangci-lint. go 1.18 does not contain JoinPath in url.