### PR TITLE
Support export by recording ID

### DIFF
--- a/foxglove/cmd/export.go
+++ b/foxglove/cmd/export.go
@@ -831,6 +831,7 @@ func executeExport(
 }
 
 func createStreamRequest(
+	recordingID string,
 	importID string,
 	deviceID string,
 	deviceName string,
@@ -859,6 +860,7 @@ func createStreamRequest(
 	topics := strings.FieldsFunc(topicList, func(c rune) bool { return c == ',' })
 
 	request := &console.StreamRequest{
+		RecordingID:  recordingID,
 		ImportID:     importID,
 		DeviceName:   deviceName,
 		DeviceID:     deviceID,
@@ -875,6 +877,7 @@ func createStreamRequest(
 }
 
 func newExportCommand(params *baseParams) (*cobra.Command, error) {
+	var recordingID string
 	var importID string
 	var deviceID string
 	var deviceName string
@@ -896,6 +899,7 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 				dief("failed to parse end time: %s", err)
 			}
 			request, err := createStreamRequest(
+				recordingID,
 				importID,
 				deviceID,
 				deviceName,
@@ -944,6 +948,7 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 	exportCmd.PersistentFlags().StringVarP(&deviceID, "device-id", "", "", "device ID")
 	exportCmd.PersistentFlags().StringVarP(&deviceName, "device-name", "", "", "device name")
 	exportCmd.PersistentFlags().StringVarP(&outputFile, "output-file", "o", "", "output file")
+	exportCmd.PersistentFlags().StringVarP(&recordingID, "recording-id", "", "", "recording ID")
 	exportCmd.PersistentFlags().StringVarP(&importID, "import-id", "", "", "import ID")
 	exportCmd.PersistentFlags().StringVarP(&start, "start", "", "", "start time (ISO8601 timestamp)")
 	exportCmd.PersistentFlags().StringVarP(&end, "end", "", "", "end time (ISO8601 timestamp")

--- a/foxglove/cmd/export.go
+++ b/foxglove/cmd/export.go
@@ -889,6 +889,7 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 	exportCmd := &cobra.Command{
 		Use:   "export",
 		Short: "Export a data selection from Foxglove Data Platform",
+		Long:  "Export a data selection from Foxglove Data Platform by Recording ID, Import ID, or Device and time range",
 		Run: func(cmd *cobra.Command, args []string) {
 			startTime, err := maybeConvertToRFC3339(start)
 			if err != nil {

--- a/foxglove/cmd/export.go
+++ b/foxglove/cmd/export.go
@@ -888,7 +888,7 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 	var outputFile string
 	exportCmd := &cobra.Command{
 		Use:   "export",
-		Short: "Export a data selection from foxglove data platform",
+		Short: "Export a data selection from Foxglove Data Platform",
 		Run: func(cmd *cobra.Command, args []string) {
 			startTime, err := maybeConvertToRFC3339(start)
 			if err != nil {

--- a/foxglove/cmd/import.go
+++ b/foxglove/cmd/import.go
@@ -34,7 +34,7 @@ func newImportCommand(params *baseParams, commandName string) (*cobra.Command, e
 	var deviceName string
 	importCmd := &cobra.Command{
 		Use:   fmt.Sprintf("%s [FILE]", commandName),
-		Short: "Import a data file to the foxglove data platform",
+		Short: "Import a data file to Foxglove Data Platform",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			filename := args[0] // guaranteed length 1 due to Args setting above

--- a/foxglove/cmd/login.go
+++ b/foxglove/cmd/login.go
@@ -27,7 +27,7 @@ func newLoginCommand(params *baseParams) *cobra.Command {
 	var baseURL string
 	loginCmd := &cobra.Command{
 		Use:   "login",
-		Short: "Log in to the foxglove data platform",
+		Short: "Log in to Foxglove Data Platform",
 		Run: func(cmd *cobra.Command, args []string) {
 			err := executeLogin(baseURL, *params.clientID, params.userAgent, &console.PlatformAuthDelegate{})
 			if err != nil {

--- a/foxglove/console/api.go
+++ b/foxglove/console/api.go
@@ -33,6 +33,7 @@ type UploadResponse struct {
 }
 
 type StreamRequest struct {
+	RecordingID  string     `json:"recordingId,omitempty"`
 	ImportID     string     `json:"importId,omitempty"`
 	DeviceID     string     `json:"device.id,omitempty"`
 	DeviceName   string     `json:"device.name,omitempty"`
@@ -43,8 +44,8 @@ type StreamRequest struct {
 }
 
 func (req *StreamRequest) Validate() error {
-	if req.ImportID == "" && req.DeviceID == "" && req.DeviceName == "" {
-		return fmt.Errorf("either import-id or device-id/device-name, start, and end are required")
+	if req.RecordingID == "" && req.ImportID == "" && req.DeviceID == "" && req.DeviceName == "" {
+		return fmt.Errorf("either recording-id, import-id, or all three of device-id/device-name, start, and end are required")
 	}
 	if req.DeviceID != "" && req.DeviceName != "" && req.ImportID == "" && (req.Start == nil || req.End == nil) {
 		return fmt.Errorf("start/end are required if device is supplied")


### PR DESCRIPTION
This adds support for exporting a recording: `foxglove data export --recording-id`.

Note that this is not part of the `recording` command, which corresponds to the API design.

I don't see a good way to add meaningful tests around this new interface, but welcome ideas.