### PR TITLE
Remove pointer to edge site

### DIFF
--- a/foxglove/console/api.go
+++ b/foxglove/console/api.go
@@ -189,7 +189,7 @@ type RecordingsResponse struct {
 	End          string           `json:"end"`
 	ImportStatus string           `json:"importStatus"`
 	Site         SiteSummary      `json:"site"`
-	EdgeSite     *SiteSummary     `json:"edgeSite"`
+	EdgeSite     SiteSummary      `json:"edgeSite"`
 	Device       DeviceSummary    `json:"device"`
 	Metadata     []MetadataRecord `json:"metadata"`
 }

--- a/foxglove/console/api_test.go
+++ b/foxglove/console/api_test.go
@@ -1,0 +1,34 @@
+package console
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecordingsFields(t *testing.T) {
+	t.Run("sets empty values for optional fields", func(t *testing.T) {
+		resp := RecordingsResponse{
+			ID:           "some-id-1",
+			Path:         "/file.mcap",
+			Size:         1024,
+			MessageCount: 1,
+			CreatedAt:    "2023-03-02T15:00:00.000Z",
+			ImportedAt:   "2023-03-03T15:00:00.000Z",
+			Start:        "2023-03-01T15:00:00.000Z",
+			End:          "2023-03-01T15:10:00.000Z",
+			ImportStatus: "pending",
+		}
+
+		edgeSiteIdx := -1
+		for i, header := range resp.Headers() {
+			if header == "Edge Site ID" {
+				edgeSiteIdx = i
+			}
+		}
+
+		assert.Greater(t, edgeSiteIdx, -1)
+		assert.Equal(t, "some-id-1", resp.Fields()[0])
+		assert.Equal(t, "", resp.Fields()[edgeSiteIdx])
+	})
+}


### PR DESCRIPTION
This fixes a crashing bug for the recordings list command when the response does not include an edgeSite property.

We changed this SiteSummary to a pointer in [the changes for wide table output](https://github.com/foxglove/foxglove-cli/pull/111/files#diff-c64282a81b5c5e0d0a42bb8fbd0a13ea25a225c948140f1454f63657047ce58eR187); if that's there for a reason, I can add a nil check instead.

Fixes #119.