### PR TITLE
Don't print progress bar when exporting JSON

### DIFF
--- a/foxglove/cmd/export.go
+++ b/foxglove/cmd/export.go
@@ -796,8 +796,11 @@ func executeExport(
 		bearerToken,
 		userAgent,
 	)
-	progressWriter := progressbar.DefaultBytes(-1, "exporting")
-	writer := io.MultiWriter(w, progressWriter)
+	writer := w
+	if stdoutRedirected() {
+		progressWriter := progressbar.DefaultBytes(-1, "exporting")
+		writer = io.MultiWriter(w, progressWriter)
+	}
 	if request.OutputFormat == "json" {
 		request.OutputFormat = "mcap0"
 		pipeReader, pipeWriter, err := os.Pipe()


### PR DESCRIPTION
When printing JSON output I found that the progress bar gets in the way. Only use it when not using JSON.