### PR TITLE
Alias --json to --output-format json

### DIFF
--- a/foxglove/cmd/configure_api_key.go
+++ b/foxglove/cmd/configure_api_key.go
@@ -20,7 +20,7 @@ func newConfigureAPIKeyCommand() *cobra.Command {
 			}
 			err := configureAuth(token, defaultString(baseURL, defaultBaseURL))
 			if err != nil {
-				dief("Configuration failed: %s\n", err)
+				dief("Configuration failed: %s", err)
 			}
 		},
 	}

--- a/foxglove/cmd/configure_api_key.go
+++ b/foxglove/cmd/configure_api_key.go
@@ -20,7 +20,7 @@ func newConfigureAPIKeyCommand() *cobra.Command {
 			}
 			err := configureAuth(token, defaultString(baseURL, defaultBaseURL))
 			if err != nil {
-				fatalf("Configuration failed: %s\n", err)
+				dief("Configuration failed: %s\n", err)
 			}
 		},
 	}

--- a/foxglove/cmd/coverage.go
+++ b/foxglove/cmd/coverage.go
@@ -50,7 +50,7 @@ func newListCoverageCommand(params *baseParams) *cobra.Command {
 				format,
 			)
 			if err != nil {
-				fatalf("Failed to list coverage: %s\n", err)
+				dief("Failed to list coverage: %s\n", err)
 			}
 		},
 	}

--- a/foxglove/cmd/coverage.go
+++ b/foxglove/cmd/coverage.go
@@ -50,7 +50,7 @@ func newListCoverageCommand(params *baseParams) *cobra.Command {
 				format,
 			)
 			if err != nil {
-				dief("Failed to list coverage: %s\n", err)
+				dief("Failed to list coverage: %s", err)
 			}
 		},
 	}

--- a/foxglove/cmd/devices.go
+++ b/foxglove/cmd/devices.go
@@ -56,7 +56,7 @@ func newAddDeviceCommand(params *baseParams) *cobra.Command {
 
 			properties, err := util.DeviceProperties(propertyPairs, client)
 			if err != nil {
-				fatalf("Failed to create device: %s\n", err)
+				dief("Failed to create device: %s\n", err)
 			}
 
 			resp, err := client.CreateDevice(console.CreateDeviceRequest{
@@ -64,7 +64,7 @@ func newAddDeviceCommand(params *baseParams) *cobra.Command {
 				Properties: properties,
 			})
 			if err != nil {
-				fatalf("Failed to create device: %s\n", err)
+				dief("Failed to create device: %s\n", err)
 			}
 			fmt.Fprintf(os.Stderr, "Device created: %s\n", resp.ID)
 		},
@@ -92,13 +92,13 @@ func newEditDeviceCommand(params *baseParams) *cobra.Command {
 
 			properties, err := util.DeviceProperties(propertyPairs, client)
 			if err != nil {
-				fatalf("Failed to edit device: %s\n", err)
+				dief("Failed to edit device: %s\n", err)
 			}
 
 			nameOrId := args[0]
 			reqBody := console.CreateDeviceRequest{}
 			if properties == nil && name == "" {
-				fatalf("Nothing to update\n")
+				dief("Nothing to update\n")
 			}
 
 			if name != "" {
@@ -113,7 +113,7 @@ func newEditDeviceCommand(params *baseParams) *cobra.Command {
 				Properties: properties,
 			})
 			if err != nil {
-				fatalf("Failed to edit device: %s\n", err)
+				dief("Failed to edit device: %s\n", err)
 			}
 			fmt.Fprintf(os.Stderr, "Device updated: %s\n", resp.Name)
 		},

--- a/foxglove/cmd/devices.go
+++ b/foxglove/cmd/devices.go
@@ -56,7 +56,7 @@ func newAddDeviceCommand(params *baseParams) *cobra.Command {
 
 			properties, err := util.DeviceProperties(propertyPairs, client)
 			if err != nil {
-				dief("Failed to create device: %s\n", err)
+				dief("Failed to create device: %s", err)
 			}
 
 			resp, err := client.CreateDevice(console.CreateDeviceRequest{
@@ -64,7 +64,7 @@ func newAddDeviceCommand(params *baseParams) *cobra.Command {
 				Properties: properties,
 			})
 			if err != nil {
-				dief("Failed to create device: %s\n", err)
+				dief("Failed to create device: %s", err)
 			}
 			fmt.Fprintf(os.Stderr, "Device created: %s\n", resp.ID)
 		},
@@ -92,13 +92,13 @@ func newEditDeviceCommand(params *baseParams) *cobra.Command {
 
 			properties, err := util.DeviceProperties(propertyPairs, client)
 			if err != nil {
-				dief("Failed to edit device: %s\n", err)
+				dief("Failed to edit device: %s", err)
 			}
 
 			nameOrId := args[0]
 			reqBody := console.CreateDeviceRequest{}
 			if properties == nil && name == "" {
-				dief("Nothing to update\n")
+				dief("Nothing to update")
 			}
 
 			if name != "" {
@@ -113,7 +113,7 @@ func newEditDeviceCommand(params *baseParams) *cobra.Command {
 				Properties: properties,
 			})
 			if err != nil {
-				dief("Failed to edit device: %s\n", err)
+				dief("Failed to edit device: %s", err)
 			}
 			fmt.Fprintf(os.Stderr, "Device updated: %s\n", resp.Name)
 		},

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -90,7 +90,7 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 				format,
 			)
 			if err != nil {
-				dief("Failed to list events: %s\n", err)
+				dief("Failed to list events: %s", err)
 			}
 		},
 	}

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -90,7 +90,7 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 				format,
 			)
 			if err != nil {
-				fatalf("Failed to list events: %s\n", err)
+				dief("Failed to list events: %s\n", err)
 			}
 		},
 	}

--- a/foxglove/cmd/export.go
+++ b/foxglove/cmd/export.go
@@ -914,7 +914,7 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 				topicList,
 			)
 			if err != nil {
-				fatalf("Failed to build request: %s\n", err)
+				dief("Failed to build request: %s\n", err)
 			}
 			if isJsonOutput && outputFormat != "json" {
 				dief("Export failed. Output format conflict: --json, --output-format ", outputFormat)
@@ -930,13 +930,13 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 					request,
 				)
 				if err != nil {
-					fatalf("Export failed: %s\n", err)
+					dief("Export failed: %s\n", err)
 				}
 				fmt.Fprint(os.Stderr, "\n")
 				return
 			}
 			if !stdoutRedirected() && request.OutputFormat != "json" {
-				fatalf("Binary output may screw up your terminal. Please redirect to a pipe or file.\n")
+				dief("Binary output may screw up your terminal. Please redirect to a pipe or file.\n")
 			}
 			defer os.Stdout.Close()
 			err = executeExport(
@@ -949,7 +949,7 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 				request,
 			)
 			if err != nil {
-				fatalf("Export failed: %s\n", err)
+				dief("Export failed: %s\n", err)
 			}
 		},
 	}

--- a/foxglove/cmd/export.go
+++ b/foxglove/cmd/export.go
@@ -919,7 +919,6 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 			if isJsonOutput {
 				outputFormat = "json"
 			}
-			println(isJsonOutput, outputFormat)
 			if outputFile != "" && outputFormat != "json" {
 				err = doExport(
 					cmd.Context(),

--- a/foxglove/cmd/export.go
+++ b/foxglove/cmd/export.go
@@ -916,8 +916,8 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 			if err != nil {
 				fatalf("Failed to build request: %s\n", err)
 			}
-			if isJsonOutput {
-				outputFormat = "json"
+			if isJsonOutput && outputFormat != "json" {
+				dief("Export failed. Output format conflict: --json, --output-format ", outputFormat)
 			}
 			if outputFile != "" && outputFormat != "json" {
 				err = doExport(

--- a/foxglove/cmd/export.go
+++ b/foxglove/cmd/export.go
@@ -914,7 +914,7 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 				topicList,
 			)
 			if err != nil {
-				dief("Failed to build request: %s\n", err)
+				dief("Failed to build request: %s", err)
 			}
 			if isJsonOutput && outputFormat != "json" {
 				dief("Export failed. Output format conflict: --json, --output-format ", outputFormat)
@@ -930,13 +930,13 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 					request,
 				)
 				if err != nil {
-					dief("Export failed: %s\n", err)
+					dief("Export failed: %s", err)
 				}
 				fmt.Fprint(os.Stderr, "\n")
 				return
 			}
 			if !stdoutRedirected() && request.OutputFormat != "json" {
-				dief("Binary output may screw up your terminal. Please redirect to a pipe or file.\n")
+				dief("Binary output may screw up your terminal. Please redirect to a pipe or file.")
 			}
 			defer os.Stdout.Close()
 			err = executeExport(
@@ -949,7 +949,7 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 				request,
 			)
 			if err != nil {
-				dief("Export failed: %s\n", err)
+				dief("Export failed: %s", err)
 			}
 		},
 	}

--- a/foxglove/cmd/export.go
+++ b/foxglove/cmd/export.go
@@ -889,6 +889,7 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 	var outputFormat string
 	var topicList string
 	var outputFile string
+	var isJsonOutput bool
 	exportCmd := &cobra.Command{
 		Use:   "export",
 		Short: "Export a data selection from Foxglove Data Platform",
@@ -915,6 +916,10 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 			if err != nil {
 				fatalf("Failed to build request: %s\n", err)
 			}
+			if isJsonOutput {
+				outputFormat = "json"
+			}
+			println(isJsonOutput, outputFormat)
 			if outputFile != "" && outputFormat != "json" {
 				err = doExport(
 					cmd.Context(),
@@ -958,6 +963,7 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 	exportCmd.PersistentFlags().StringVarP(&end, "end", "", "", "end time (ISO8601 timestamp")
 	exportCmd.PersistentFlags().StringVarP(&outputFormat, "output-format", "", "mcap0", "output format (mcap0, bag1, or json)")
 	exportCmd.PersistentFlags().StringVarP(&topicList, "topics", "", "", "comma separated list of topics")
+	exportCmd.PersistentFlags().BoolVar(&isJsonOutput, "json", false, "alias for --output-format json")
 	AddDeviceAutocompletion(exportCmd, params)
 	return exportCmd, nil
 }

--- a/foxglove/cmd/extensions.go
+++ b/foxglove/cmd/extensions.go
@@ -36,7 +36,7 @@ func newPublishExtensionCommand(params *baseParams) *cobra.Command {
 				filename,
 			)
 			if err != nil {
-				fatalf("Extension upload failed: %s\n", err)
+				dief("Extension upload failed: %s\n", err)
 			}
 			fmt.Fprintln(os.Stderr, "Extension published")
 		},
@@ -64,7 +64,7 @@ func newListExtensionsCommand(params *baseParams) *cobra.Command {
 			)
 
 			if err != nil {
-				fatalf("Failed to list extensions: %s\n", err)
+				dief("Failed to list extensions: %s\n", err)
 			}
 		},
 	}
@@ -86,7 +86,7 @@ func newUnpublishExtensionCommand(params *baseParams) *cobra.Command {
 			)
 			err := executeExtensionDelete(client, args[0])
 			if err != nil {
-				fatalf("Failed to delete extension: %s\n", err)
+				dief("Failed to delete extension: %s\n", err)
 			}
 			fmt.Fprintln(os.Stderr, "Extension deleted")
 		},

--- a/foxglove/cmd/extensions.go
+++ b/foxglove/cmd/extensions.go
@@ -36,7 +36,7 @@ func newPublishExtensionCommand(params *baseParams) *cobra.Command {
 				filename,
 			)
 			if err != nil {
-				dief("Extension upload failed: %s\n", err)
+				dief("Extension upload failed: %s", err)
 			}
 			fmt.Fprintln(os.Stderr, "Extension published")
 		},
@@ -64,7 +64,7 @@ func newListExtensionsCommand(params *baseParams) *cobra.Command {
 			)
 
 			if err != nil {
-				dief("Failed to list extensions: %s\n", err)
+				dief("Failed to list extensions: %s", err)
 			}
 		},
 	}
@@ -86,7 +86,7 @@ func newUnpublishExtensionCommand(params *baseParams) *cobra.Command {
 			)
 			err := executeExtensionDelete(client, args[0])
 			if err != nil {
-				dief("Failed to delete extension: %s\n", err)
+				dief("Failed to delete extension: %s", err)
 			}
 			fmt.Fprintln(os.Stderr, "Extension deleted")
 		},

--- a/foxglove/cmd/import.go
+++ b/foxglove/cmd/import.go
@@ -70,13 +70,13 @@ func newImportCommand(params *baseParams, commandName string) (*cobra.Command, e
 					params.userAgent,
 				)
 				if err != nil {
-					dief("Failed to import %s: %s\n", filename, err)
+					dief("Failed to import %s: %s", filename, err)
 				}
 			}
 			if edgeRecordingID != "" {
 				err := importFromEdge(params.baseURL, *params.clientID, params.token, params.userAgent, edgeRecordingID)
 				if err != nil {
-					dief("Failed to import edge recording: %s\n", err)
+					dief("Failed to import edge recording: %s", err)
 				}
 			}
 		},

--- a/foxglove/cmd/login.go
+++ b/foxglove/cmd/login.go
@@ -31,7 +31,7 @@ func newLoginCommand(params *baseParams) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := executeLogin(baseURL, *params.clientID, params.userAgent, &console.PlatformAuthDelegate{})
 			if err != nil {
-				dief("Login failed: %s\n", err)
+				dief("Login failed: %s", err)
 			}
 		},
 	}

--- a/foxglove/cmd/login.go
+++ b/foxglove/cmd/login.go
@@ -31,7 +31,7 @@ func newLoginCommand(params *baseParams) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := executeLogin(baseURL, *params.clientID, params.userAgent, &console.PlatformAuthDelegate{})
 			if err != nil {
-				fatalf("Login failed: %s\n", err)
+				dief("Login failed: %s\n", err)
 			}
 		},
 	}

--- a/foxglove/cmd/utils.go
+++ b/foxglove/cmd/utils.go
@@ -144,11 +144,6 @@ func debugf(format string, args ...any) {
 	}
 }
 
-func fatalf(format string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, format, args...)
-	os.Exit(1)
-}
-
 // Define a `format` flag on a command for one of the formats above
 func AddFormatFlag(cmd *cobra.Command, format *string) {
 	cmd.PersistentFlags().StringVarP(


### PR DESCRIPTION
This aliases `--json` to `--output-format json` for convenience.
