### PR TITLE
Add --json alias if --format json is supported

### DIFF
--- a/foxglove/cmd/attachments.go
+++ b/foxglove/cmd/attachments.go
@@ -19,7 +19,7 @@ func newListAttachmentsCommand(params *baseParams) *cobra.Command {
 		Use:   "list",
 		Short: "List MCAP attachments",
 		Run: func(cmd *cobra.Command, args []string) {
-			format = EnsureFormatFlagsNotConflicting(format, isJsonFormat)
+			format = ResolveFormat(format, isJsonFormat)
 			client := console.NewRemoteFoxgloveClient(
 				params.baseURL, *params.clientID,
 				viper.GetString("bearer_token"),

--- a/foxglove/cmd/attachments.go
+++ b/foxglove/cmd/attachments.go
@@ -14,10 +14,12 @@ func newListAttachmentsCommand(params *baseParams) *cobra.Command {
 	var format string
 	var importID string
 	var recordingID string
+	var isJsonFormat bool
 	attachmentsListCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List MCAP attachments",
 		Run: func(cmd *cobra.Command, args []string) {
+			format = EnsureFormatFlagsNotConflicting(format, isJsonFormat)
 			client := console.NewRemoteFoxgloveClient(
 				params.baseURL, *params.clientID,
 				viper.GetString("bearer_token"),
@@ -42,6 +44,7 @@ func newListAttachmentsCommand(params *baseParams) *cobra.Command {
 	attachmentsListCmd.PersistentFlags().StringVarP(&importID, "import-id", "", "", "Import ID")
 	attachmentsListCmd.PersistentFlags().StringVarP(&recordingID, "recording-id", "", "", "Recording ID")
 	AddFormatFlag(attachmentsListCmd, &format)
+	AddJsonFlag(attachmentsListCmd, &isJsonFormat)
 	return attachmentsListCmd
 }
 

--- a/foxglove/cmd/coverage.go
+++ b/foxglove/cmd/coverage.go
@@ -36,7 +36,7 @@ func newListCoverageCommand(params *baseParams) *cobra.Command {
 			if err != nil {
 				dief("failed to parse end time: %s", err)
 			}
-			format = EnsureFormatFlagsNotConflicting(format, isJsonFormat)
+			format = ResolveFormat(format, isJsonFormat)
 			err = renderList(
 				os.Stdout,
 				&console.CoverageRequest{

--- a/foxglove/cmd/coverage.go
+++ b/foxglove/cmd/coverage.go
@@ -16,6 +16,7 @@ func newListCoverageCommand(params *baseParams) *cobra.Command {
 	var tolerance int
 	var recordingID string
 	var includeEdgeRecordings bool
+	var isJsonFormat bool
 	coverageListCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List coverage ranges",
@@ -35,6 +36,7 @@ func newListCoverageCommand(params *baseParams) *cobra.Command {
 			if err != nil {
 				dief("failed to parse end time: %s", err)
 			}
+			format = EnsureFormatFlagsNotConflicting(format, isJsonFormat)
 			err = renderList(
 				os.Stdout,
 				&console.CoverageRequest{
@@ -66,5 +68,6 @@ func newListCoverageCommand(params *baseParams) *cobra.Command {
 	coverageListCmd.PersistentFlags().StringVarP(&end, "end", "", "", "end of coverage time range (ISO8601)")
 	AddFormatFlag(coverageListCmd, &format)
 	AddDeviceAutocompletion(coverageListCmd, params)
+	AddJsonFlag(coverageListCmd, &isJsonFormat)
 	return coverageListCmd
 }

--- a/foxglove/cmd/devices.go
+++ b/foxglove/cmd/devices.go
@@ -21,7 +21,7 @@ func newListDevicesCommand(params *baseParams) *cobra.Command {
 				params.token,
 				params.userAgent,
 			)
-			format = EnsureFormatFlagsNotConflicting(format, isJsonFormat)
+			format = ResolveFormat(format, isJsonFormat)
 			err := renderList(
 				os.Stdout,
 				console.DevicesRequest{},

--- a/foxglove/cmd/devices.go
+++ b/foxglove/cmd/devices.go
@@ -11,6 +11,7 @@ import (
 
 func newListDevicesCommand(params *baseParams) *cobra.Command {
 	var format string
+	var isJsonFormat bool
 	deviceListCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List devices registered to your organization",
@@ -20,6 +21,7 @@ func newListDevicesCommand(params *baseParams) *cobra.Command {
 				params.token,
 				params.userAgent,
 			)
+			format = EnsureFormatFlagsNotConflicting(format, isJsonFormat)
 			err := renderList(
 				os.Stdout,
 				console.DevicesRequest{},
@@ -33,6 +35,7 @@ func newListDevicesCommand(params *baseParams) *cobra.Command {
 	}
 	deviceListCmd.InheritedFlags()
 	AddFormatFlag(deviceListCmd, &format)
+	AddJsonFlag(deviceListCmd, &isJsonFormat)
 	return deviceListCmd
 }
 

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -64,6 +64,7 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 	var start string
 	var end string
 	var query string
+	var isJsonFormat bool
 	eventsListCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List events",
@@ -73,6 +74,7 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 				params.token,
 				params.userAgent,
 			)
+			format = EnsureFormatFlagsNotConflicting(format, isJsonFormat)
 			err := renderList(
 				os.Stdout,
 				&console.EventsRequest{
@@ -104,5 +106,6 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 	eventsListCmd.PersistentFlags().StringVarP(&query, "query", "", "", "Filter by metadata with keyword or \"$key:$value\"")
 	AddDeviceAutocompletion(eventsListCmd, params)
 	AddFormatFlag(eventsListCmd, &format)
+	AddJsonFlag(eventsListCmd, &isJsonFormat)
 	return eventsListCmd
 }

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -74,7 +74,7 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 				params.token,
 				params.userAgent,
 			)
-			format = EnsureFormatFlagsNotConflicting(format, isJsonFormat)
+			format = ResolveFormat(format, isJsonFormat)
 			err := renderList(
 				os.Stdout,
 				&console.EventsRequest{

--- a/foxglove/cmd/extensions.go
+++ b/foxglove/cmd/extensions.go
@@ -57,7 +57,7 @@ func newListExtensionsCommand(params *baseParams) *cobra.Command {
 				params.token,
 				params.userAgent,
 			)
-			format = EnsureFormatFlagsNotConflicting(format, isJsonFormat)
+			format = ResolveFormat(format, isJsonFormat)
 			err := renderList(
 				os.Stdout,
 				console.ExtensionsRequest{},

--- a/foxglove/cmd/extensions.go
+++ b/foxglove/cmd/extensions.go
@@ -47,6 +47,7 @@ func newPublishExtensionCommand(params *baseParams) *cobra.Command {
 
 func newListExtensionsCommand(params *baseParams) *cobra.Command {
 	var format string
+	var isJsonFormat bool
 	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List Studio extensions created for your organization",
@@ -56,6 +57,7 @@ func newListExtensionsCommand(params *baseParams) *cobra.Command {
 				params.token,
 				params.userAgent,
 			)
+			format = EnsureFormatFlagsNotConflicting(format, isJsonFormat)
 			err := renderList(
 				os.Stdout,
 				console.ExtensionsRequest{},
@@ -70,6 +72,7 @@ func newListExtensionsCommand(params *baseParams) *cobra.Command {
 	}
 	listCmd.InheritedFlags()
 	AddFormatFlag(listCmd, &format)
+	AddJsonFlag(listCmd, &isJsonFormat)
 	return listCmd
 }
 

--- a/foxglove/cmd/imports.go
+++ b/foxglove/cmd/imports.go
@@ -16,6 +16,7 @@ func newListImportsCommand(params *baseParams) *cobra.Command {
 	var dataStart string
 	var includeDeleted bool
 	var dataEnd string
+	var isJsonFormat bool
 	importsListCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List imports for a device",
@@ -41,6 +42,7 @@ func newListImportsCommand(params *baseParams) *cobra.Command {
 			if err != nil {
 				dief("failed to parse data end time: %s", err)
 			}
+			format = EnsureFormatFlagsNotConflicting(format, isJsonFormat)
 			err = renderList(
 				os.Stdout,
 				&console.ImportsRequest{
@@ -68,5 +70,6 @@ func newListImportsCommand(params *baseParams) *cobra.Command {
 	importsListCmd.PersistentFlags().StringVarP(&dataEnd, "data-end", "", "", "end of data time range (ISO8601)")
 	importsListCmd.PersistentFlags().BoolVarP(&includeDeleted, "include-deleted", "", false, "end of data time range")
 	AddFormatFlag(importsListCmd, &format)
+	AddJsonFlag(importsListCmd, &isJsonFormat)
 	return importsListCmd
 }

--- a/foxglove/cmd/imports.go
+++ b/foxglove/cmd/imports.go
@@ -42,7 +42,7 @@ func newListImportsCommand(params *baseParams) *cobra.Command {
 			if err != nil {
 				dief("failed to parse data end time: %s", err)
 			}
-			format = EnsureFormatFlagsNotConflicting(format, isJsonFormat)
+			format = ResolveFormat(format, isJsonFormat)
 			err = renderList(
 				os.Stdout,
 				&console.ImportsRequest{

--- a/foxglove/cmd/pending_imports.go
+++ b/foxglove/cmd/pending_imports.go
@@ -19,6 +19,7 @@ func newPendingImportsCommand(params *baseParams) *cobra.Command {
 	var showQuarantined bool
 	var siteId string
 	var updatedSince string
+	var isJsonFormat bool
 	pendingImportsCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List the pending and errored import jobs for uploaded recordings",
@@ -33,6 +34,7 @@ func newPendingImportsCommand(params *baseParams) *cobra.Command {
 				fmt.Fprintf(os.Stderr, "Failed to parse value of --updated-since: %s\n", err)
 				os.Exit(1)
 			}
+			format = EnsureFormatFlagsNotConflicting(format, isJsonFormat)
 			err = renderList(
 				os.Stdout,
 				console.PendingImportsRequest{
@@ -66,5 +68,6 @@ func newPendingImportsCommand(params *baseParams) *cobra.Command {
 	pendingImportsCmd.PersistentFlags().StringVarP(&siteId, "site-id", "", "", "Site ID")
 	pendingImportsCmd.PersistentFlags().StringVarP(&updatedSince, "updated-since", "", "", "Filter pending imports updated since this time (ISO8601)")
 	AddFormatFlag(pendingImportsCmd, &format)
+	AddJsonFlag(pendingImportsCmd, &isJsonFormat)
 	return pendingImportsCmd
 }

--- a/foxglove/cmd/pending_imports.go
+++ b/foxglove/cmd/pending_imports.go
@@ -34,7 +34,7 @@ func newPendingImportsCommand(params *baseParams) *cobra.Command {
 				fmt.Fprintf(os.Stderr, "Failed to parse value of --updated-since: %s\n", err)
 				os.Exit(1)
 			}
-			format = EnsureFormatFlagsNotConflicting(format, isJsonFormat)
+			format = ResolveFormat(format, isJsonFormat)
 			err = renderList(
 				os.Stdout,
 				console.PendingImportsRequest{

--- a/foxglove/cmd/recordings.go
+++ b/foxglove/cmd/recordings.go
@@ -36,7 +36,7 @@ func newListRecordingsCommand(params *baseParams) *cobra.Command {
 			if err != nil {
 				dief("failed to parse end time: %s", err)
 			}
-			format = EnsureFormatFlagsNotConflicting(format, isJsonFormat)
+			format = ResolveFormat(format, isJsonFormat)
 			err = renderList(
 				os.Stdout,
 				&console.RecordingsRequest{

--- a/foxglove/cmd/recordings.go
+++ b/foxglove/cmd/recordings.go
@@ -18,6 +18,7 @@ func newListRecordingsCommand(params *baseParams) *cobra.Command {
 	var start string
 	var end string
 	var importStatus string
+	var isJsonFormat bool
 	recordingsListCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List recordings",
@@ -35,6 +36,7 @@ func newListRecordingsCommand(params *baseParams) *cobra.Command {
 			if err != nil {
 				dief("failed to parse end time: %s", err)
 			}
+			format = EnsureFormatFlagsNotConflicting(format, isJsonFormat)
 			err = renderList(
 				os.Stdout,
 				&console.RecordingsRequest{
@@ -67,5 +69,6 @@ func newListRecordingsCommand(params *baseParams) *cobra.Command {
 	recordingsListCmd.PersistentFlags().StringVarP(&importStatus, "import-status", "", "", "import status")
 	AddFormatFlag(recordingsListCmd, &format)
 	AddDeviceAutocompletion(recordingsListCmd, params)
+	AddJsonFlag(recordingsListCmd, &isJsonFormat)
 	return recordingsListCmd
 }

--- a/foxglove/cmd/utils.go
+++ b/foxglove/cmd/utils.go
@@ -160,7 +160,7 @@ func AddJsonFlag(cmd *cobra.Command, isJsonFormat *bool) {
 		isJsonFormat,
 		"json",
 		false,
-		"render output in specified format (table, json, csv)",
+		"alias for --format json",
 	)
 }
 

--- a/foxglove/cmd/utils.go
+++ b/foxglove/cmd/utils.go
@@ -165,7 +165,7 @@ func AddJsonFlag(cmd *cobra.Command, isJsonFormat *bool) {
 }
 
 // Ensure --json alias is not conflicting with --format's value
-func EnsureFormatFlagsNotConflicting(formatFlagValue string, jsonFlagValue bool) string {
+func ResolveFormat(formatFlagValue string, jsonFlagValue bool) string {
 	if formatFlagValue == "" {
 		if jsonFlagValue {
 			return "json"

--- a/foxglove/cmd/utils.go
+++ b/foxglove/cmd/utils.go
@@ -150,9 +150,35 @@ func AddFormatFlag(cmd *cobra.Command, format *string) {
 		format,
 		"format",
 		"",
-		"table",
+		"",
 		"render output in specified format (table, json, csv)",
 	)
+}
+
+func AddJsonFlag(cmd *cobra.Command, isJsonFormat *bool) {
+	cmd.PersistentFlags().BoolVar(
+		isJsonFormat,
+		"json",
+		false,
+		"render output in specified format (table, json, csv)",
+	)
+}
+
+// Ensure --json alias is not conflicting with --format's value
+func EnsureFormatFlagsNotConflicting(formatFlagValue string, jsonFlagValue bool) string {
+	if formatFlagValue == "" {
+		if jsonFlagValue {
+			return "json"
+		} else {
+			return "table"
+		}
+	}
+
+	if jsonFlagValue && formatFlagValue != "json" {
+		dief("Command failed. Output format conflict: --json, --format")
+	}
+
+	return formatFlagValue
 }
 
 // AddDeviceAutocompletion adds autocompletion for device-name and device-id


### PR DESCRIPTION
This add a `--json` alias for all commands that support `--format json`
