### PR TITLE
Build CLI with -tags 'netgo'

### DIFF
--- a/foxglove/Makefile
+++ b/foxglove/Makefile
@@ -15,11 +15,11 @@ version:
 	@echo VERSION=$(VERSION)
 
 build: version
-	go build -ldflags "-X main.Version=$(VERSION)"
+	go build -tags 'netgo' -ldflags '-X main.Version=$(VERSION)'
 
 build-release: version
 	mkdir -p bin
-	go build -ldflags "-X main.Version=$(VERSION)" -o bin/$(BINARY_NAME)
+	go build -tags 'netgo' -ldflags '-X main.Version=$(VERSION)' -o bin/$(BINARY_NAME)
 
 install: version
-	go install -ldflags "-X main.Version=$(VERSION)"
+	go install -tags 'netgo' -ldflags '-X main.Version=$(VERSION)'


### PR DESCRIPTION
By default we are relying on cgo for DNS resolution, which causes
binaries built on ubuntu 22.04 to break on ubuntu 20.04 due to some
changes in glibc. See https://github.com/golang/go/issues/57328

This changes us to not rely on that, which causes builds to succeed.