### PR TITLE
Add info command

### DIFF
--- a/foxglove/cmd/configure_api_key.go
+++ b/foxglove/cmd/configure_api_key.go
@@ -18,7 +18,7 @@ func newConfigureAPIKeyCommand() *cobra.Command {
 				prompt := fmt.Sprintf("Enter an API key (will be written to %s):\n", viper.ConfigFileUsed())
 				token = promptForInput(prompt)
 			}
-			err := configureAuth(token, defaultString(baseURL, defaultBaseURL))
+			err := configureAuth(token, defaultString(baseURL, defaultBaseURL), TokenApiKey)
 			if err != nil {
 				dief("Configuration failed: %s", err)
 			}

--- a/foxglove/cmd/info.go
+++ b/foxglove/cmd/info.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/foxglove/foxglove-cli/foxglove/console"
+
+	"github.com/spf13/cobra"
+)
+
+func executeInfo(baseURL, clientID, token, userAgent string) error {
+	client := console.NewRemoteFoxgloveClient(baseURL, clientID, token, userAgent)
+	me, err := client.Me()
+	if err != nil {
+		return err
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 1, 1, ' ', 0)
+	fmt.Fprintln(w, "Email\t", me.Email)
+	fmt.Fprintln(w, "Email verified\t", me.EmailVerified)
+	fmt.Fprintln(w, "Org ID\t", me.OrgId)
+	fmt.Fprintln(w, "Org Slug\t", me.OrgSlug)
+	fmt.Fprintln(w, "Admin\t", me.Admin)
+	fmt.Fprintln(w, "Token type\t", "session")
+	w.Flush()
+
+	return nil
+}
+
+func newInfoCommand(params *baseParams) *cobra.Command {
+	loginCmd := &cobra.Command{
+		Use:   "info",
+		Short: "Display information about the currently logged-in user",
+		Run: func(cmd *cobra.Command, args []string) {
+			err := executeInfo(params.baseURL, *params.clientID, params.token, params.userAgent)
+			if err != nil {
+				dief("Info command failed: %s", err)
+			}
+		},
+	}
+	loginCmd.InheritedFlags()
+	return loginCmd
+}

--- a/foxglove/cmd/info.go
+++ b/foxglove/cmd/info.go
@@ -12,6 +12,12 @@ import (
 )
 
 func executeInfo(baseURL, clientID, token, userAgent string) error {
+	isUsingApiKey := TokenIsApiKey(token)
+	if isUsingApiKey {
+		fmt.Println("Authenticated with API key")
+		return nil
+	}
+
 	client := console.NewRemoteFoxgloveClient(baseURL, clientID, token, userAgent)
 	me, err := client.Me()
 	if err != nil {
@@ -46,10 +52,6 @@ func newInfoCommand(params *baseParams) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			if !IsAuthenticated() {
 				dief("Not signed in. Run `foxglove auth login` or `foxglove auth configure-api-key` to continue.")
-			}
-			isUsingApiKey := TokenIsApiKey(params.token)
-			if isUsingApiKey {
-				dief("Authenticated with API key. Command not available for auth with api keys.")
 			}
 			err := executeInfo(params.baseURL, *params.clientID, params.token, params.userAgent)
 			if err != nil {

--- a/foxglove/cmd/info.go
+++ b/foxglove/cmd/info.go
@@ -11,6 +11,13 @@ import (
 )
 
 func executeInfo(baseURL, clientID, token, userAgent string) error {
+	isUsingApiKey, err := AuthIsApiKey()
+	if err != nil {
+		return err
+	}
+	if isUsingApiKey {
+		dief("Command not available for auth with api keys")
+	}
 	client := console.NewRemoteFoxgloveClient(baseURL, clientID, token, userAgent)
 	me, err := client.Me()
 	if err != nil {
@@ -22,7 +29,6 @@ func executeInfo(baseURL, clientID, token, userAgent string) error {
 	fmt.Fprintln(w, "Org ID\t", me.OrgId)
 	fmt.Fprintln(w, "Org Slug\t", me.OrgSlug)
 	fmt.Fprintln(w, "Admin\t", me.Admin)
-	fmt.Fprintln(w, "Token type\t", "session")
 	w.Flush()
 
 	return nil

--- a/foxglove/cmd/login.go
+++ b/foxglove/cmd/login.go
@@ -16,7 +16,7 @@ func executeLogin(baseURL, clientID, userAgent string, authDelegate console.Auth
 	if err != nil {
 		return err
 	}
-	err = configureAuth(bearerToken, baseURL)
+	err = configureAuth(bearerToken, baseURL, TokenSession)
 	if err != nil {
 		return fmt.Errorf("Failed to configure auth: %w", err)
 	}

--- a/foxglove/cmd/root.go
+++ b/foxglove/cmd/root.go
@@ -25,9 +25,17 @@ func configfile() (string, error) {
 	return path.Join(home, ".foxgloverc"), nil
 }
 
-func configureAuth(token, baseURL string) error {
+type AuthType int
+
+const (
+	TokenSession AuthType = iota
+	TokenApiKey
+)
+
+func configureAuth(token, baseURL string, authType AuthType) error {
 	viper.Set("bearer_token", token)
 	viper.Set("base_url", baseURL)
+	viper.Set("auth_type", authType)
 	err := viper.WriteConfigAs(viper.ConfigFileUsed())
 	if err != nil {
 		return fmt.Errorf("Failed to write config: %w", err)

--- a/foxglove/cmd/root.go
+++ b/foxglove/cmd/root.go
@@ -28,7 +28,8 @@ func configfile() (string, error) {
 type AuthType int
 
 const (
-	TokenSession AuthType = iota
+	Unknown AuthType = iota
+	TokenSession
 	TokenApiKey
 )
 

--- a/foxglove/cmd/root.go
+++ b/foxglove/cmd/root.go
@@ -198,6 +198,7 @@ func Execute(version string) {
 	configureAPIKey := newConfigureAPIKeyCommand()
 	authCmd.AddCommand(loginCmd)
 	authCmd.AddCommand(configureAPIKey)
+	authCmd.AddCommand(infoCmd)
 	recordingsCmd.AddCommand(newListRecordingsCommand(params))
 	importsCmd.AddCommand(newListImportsCommand(params), addImportCmd)
 	attachmentsCmd.AddCommand(newListAttachmentsCommand(params))
@@ -226,7 +227,6 @@ func Execute(version string) {
 		recordingsCmd,
 		eventsCmd,
 		pendingImportsCmd,
-		infoCmd,
 	)
 
 	cobra.CheckErr(rootCmd.Execute())

--- a/foxglove/cmd/root.go
+++ b/foxglove/cmd/root.go
@@ -194,6 +194,7 @@ func Execute(version string) {
 		return
 	}
 	loginCmd := newLoginCommand(params)
+	infoCmd := newInfoCommand(params)
 	configureAPIKey := newConfigureAPIKeyCommand()
 	authCmd.AddCommand(loginCmd)
 	authCmd.AddCommand(configureAPIKey)
@@ -225,6 +226,7 @@ func Execute(version string) {
 		recordingsCmd,
 		eventsCmd,
 		pendingImportsCmd,
+		infoCmd,
 	)
 
 	cobra.CheckErr(rootCmd.Execute())

--- a/foxglove/cmd/utils.go
+++ b/foxglove/cmd/utils.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/foxglove/foxglove-cli/foxglove/console"
@@ -232,10 +231,11 @@ func maybeConvertToRFC3339(timestamp string) (string, error) {
 }
 
 func TokenIsApiKey(token string) bool {
-	return strings.HasPrefix(token, "fox_sk_")
+	authType := viper.GetInt("auth_type")
+	return AuthType(authType) == TokenApiKey
 }
 
 func IsAuthenticated() bool {
-  token := viper.GetString("bearer_token")
-  return token != ""
+	token := viper.GetString("bearer_token")
+	return token != ""
 }

--- a/foxglove/cmd/utils.go
+++ b/foxglove/cmd/utils.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/foxglove/foxglove-cli/foxglove/console"
@@ -232,7 +233,14 @@ func maybeConvertToRFC3339(timestamp string) (string, error) {
 
 func TokenIsApiKey(token string) bool {
 	authType := viper.GetInt("auth_type")
-	return AuthType(authType) == TokenApiKey
+	switch AuthType(authType) {
+	case TokenApiKey:
+		return true
+	case TokenSession:
+		return false
+	default:
+		return strings.HasPrefix(token, "fox_sk_")
+	}
 }
 
 func IsAuthenticated() bool {

--- a/foxglove/cmd/utils.go
+++ b/foxglove/cmd/utils.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/foxglove/foxglove-cli/foxglove/console"
@@ -15,6 +16,7 @@ import (
 	"github.com/foxglove/mcap/go/mcap"
 	"github.com/relvacode/iso8601"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var ErrTruncatedMCAP = errors.New("truncated mcap file")
@@ -227,4 +229,13 @@ func maybeConvertToRFC3339(timestamp string) (string, error) {
 		return "", err
 	}
 	return parsed.Format(time.RFC3339), nil
+}
+
+func AuthIsApiKey() (bool, error) {
+	token := viper.Get("bearer_token")
+	if token == nil {
+		dief("Auth is not setup. Run `foxglove auth login` or `foxglove auth configure-api-key` to continue.")
+	}
+	stringifiedToken := fmt.Sprintf("%v", token)
+	return strings.HasPrefix(stringifiedToken, "fox_sk_"), nil
 }

--- a/foxglove/cmd/utils.go
+++ b/foxglove/cmd/utils.go
@@ -231,11 +231,11 @@ func maybeConvertToRFC3339(timestamp string) (string, error) {
 	return parsed.Format(time.RFC3339), nil
 }
 
-func AuthIsApiKey() (bool, error) {
-	token := viper.Get("bearer_token")
-	if token == nil {
-		dief("Auth is not setup. Run `foxglove auth login` or `foxglove auth configure-api-key` to continue.")
-	}
-	stringifiedToken := fmt.Sprintf("%v", token)
-	return strings.HasPrefix(stringifiedToken, "fox_sk_"), nil
+func TokenIsApiKey(token string) bool {
+	return strings.HasPrefix(token, "fox_sk_")
+}
+
+func IsAuthenticated() bool {
+  token := viper.GetString("bearer_token")
+  return token != ""
 }

--- a/foxglove/console/api.go
+++ b/foxglove/console/api.go
@@ -541,6 +541,18 @@ type ImportFromEdgeResponse struct {
 	ImportStatus string `json:"importStatus"`
 }
 
+type MeRequest struct{}
+
+type MeResponse struct {
+	ID             string `json:"id"`
+	OrgId          string `json:"orgId"`
+	OrgDisplayName string `json:"orgDisplayName"`
+	OrgSlug        string `json:"orgSlug"`
+	Email          string `json:"email"`
+	EmailVerified  bool   `json:"emailVerified"`
+	Admin          bool   `json:"admin"`
+}
+
 func requiredVal(val *string) string {
 	if val != nil {
 		return *val

--- a/foxglove/console/client.go
+++ b/foxglove/console/client.go
@@ -413,6 +413,12 @@ func (c *FoxgloveClient) ImportFromEdge(req ImportFromEdgeRequest, id string) (r
 	return resp, err
 }
 
+func (c *FoxgloveClient) Me() (resp MeResponse, err error) {
+	req := MeRequest{}
+	err = c.get("/v1/me", req, &resp)
+	return resp, err
+}
+
 // Token returns a token for the provided device code. If the token for the
 // device code does not exist yet, ErrForbidden is returned. It is up to the
 // caller to give up after sufficient retries.


### PR DESCRIPTION
This commit adds a command to display info (such as org id, org name, email used, etc.) which should make it easier to debug request failures from users.