### PR TITLE
feat: add support for delete recording

### DIFF
--- a/foxglove/cmd/recordings.go
+++ b/foxglove/cmd/recordings.go
@@ -72,3 +72,19 @@ func newListRecordingsCommand(params *baseParams) *cobra.Command {
 	AddJsonFlag(recordingsListCmd, &isJsonFormat)
 	return recordingsListCmd
 }
+
+func newDeleteRecordingCommand(params *baseParams) *cobra.Command {
+	deleteCmd := &cobra.Command{
+		Use:   "delete [ID]",
+		Short: "Delete a recording from your organization",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			client := console.NewRemoteFoxgloveClient(params.baseURL, *params.clientID, params.token, params.userAgent)
+			if err := client.DeleteRecording(args[0]); err != nil {
+				dief("Failed to delete recording: %s", err)
+			}
+		},
+	}
+	deleteCmd.InheritedFlags()
+	return deleteCmd
+}

--- a/foxglove/cmd/root.go
+++ b/foxglove/cmd/root.go
@@ -209,6 +209,7 @@ func Execute(version string) {
 	authCmd.AddCommand(configureAPIKey)
 	authCmd.AddCommand(infoCmd)
 	recordingsCmd.AddCommand(newListRecordingsCommand(params))
+	recordingsCmd.AddCommand(newDeleteRecordingCommand(params))
 	importsCmd.AddCommand(newListImportsCommand(params), addImportCmd)
 	attachmentsCmd.AddCommand(newListAttachmentsCommand(params))
 	attachmentsCmd.AddCommand(newDownloadAttachmentCmd(params))

--- a/foxglove/console/client.go
+++ b/foxglove/console/client.go
@@ -375,6 +375,10 @@ func (c *FoxgloveClient) Recordings(req *RecordingsRequest) (resp []RecordingsRe
 	return resp, err
 }
 
+func (c *FoxgloveClient) DeleteRecording(id string) error {
+	return c.delete("/v1/recordings/" + id)
+}
+
 func (c *FoxgloveClient) Attachments(req *AttachmentsRequest) (resp []AttachmentsResponse, err error) {
 	err = c.get("/v1/recording-attachments", req, &resp)
 	return resp, err


### PR DESCRIPTION
### Public-Facing Changes
Adds a CLI command to delete recording

### Description

Allows deleting a recording using the client, also adds a CLI command for that.

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
