### PR TITLE
Rename `console` to `api`

### DIFF
--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -1,4 +1,4 @@
-package console
+package api
 
 import (
 	"encoding/json"

--- a/foxglove/api/api_test.go
+++ b/foxglove/api/api_test.go
@@ -1,4 +1,4 @@
-package console
+package api
 
 import (
 	"testing"

--- a/foxglove/api/client.go
+++ b/foxglove/api/client.go
@@ -1,4 +1,4 @@
-package console
+package api
 
 import (
 	"bytes"

--- a/foxglove/api/lib.go
+++ b/foxglove/api/lib.go
@@ -1,4 +1,4 @@
-package console
+package api
 
 import (
 	"context"

--- a/foxglove/api/lib_test.go
+++ b/foxglove/api/lib_test.go
@@ -1,4 +1,4 @@
-package console
+package api
 
 import (
 	"bytes"

--- a/foxglove/api/mock_client.go
+++ b/foxglove/api/mock_client.go
@@ -1,4 +1,4 @@
-package console
+package api
 
 import (
 	"testing"

--- a/foxglove/api/mock_service.go
+++ b/foxglove/api/mock_service.go
@@ -1,4 +1,4 @@
-package console
+package api
 
 import (
 	"context"

--- a/foxglove/cmd/attachments.go
+++ b/foxglove/cmd/attachments.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -20,14 +20,14 @@ func newListAttachmentsCommand(params *baseParams) *cobra.Command {
 		Short: "List MCAP attachments",
 		Run: func(cmd *cobra.Command, args []string) {
 			format = ResolveFormat(format, isJsonFormat)
-			client := console.NewRemoteFoxgloveClient(
+			client := api.NewRemoteFoxgloveClient(
 				params.baseURL, *params.clientID,
 				viper.GetString("bearer_token"),
 				params.userAgent,
 			)
 			err := renderList(
 				os.Stdout,
-				&console.AttachmentsRequest{
+				&api.AttachmentsRequest{
 					ImportID:    importID,
 					RecordingID: recordingID,
 				},
@@ -55,7 +55,7 @@ func newDownloadAttachmentCmd(params *baseParams) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			attachmentID := args[0]
-			client := console.NewRemoteFoxgloveClient(
+			client := api.NewRemoteFoxgloveClient(
 				params.baseURL, *params.clientID,
 				viper.GetString("bearer_token"),
 				params.userAgent,

--- a/foxglove/cmd/configure_api_key.go
+++ b/foxglove/cmd/configure_api_key.go
@@ -25,7 +25,7 @@ func newConfigureAPIKeyCommand() *cobra.Command {
 		},
 	}
 	configCmd.PersistentFlags().StringVarP(&token, "api-key", "", "", "api key (for non-interactive use)")
-	configCmd.PersistentFlags().StringVarP(&baseURL, "base-url", "", defaultBaseURL, "console API server")
+	configCmd.PersistentFlags().StringVarP(&baseURL, "base-url", "", defaultBaseURL, "API server")
 	configCmd.InheritedFlags()
 	return configCmd
 }

--- a/foxglove/cmd/coverage.go
+++ b/foxglove/cmd/coverage.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"os"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +21,7 @@ func newListCoverageCommand(params *baseParams) *cobra.Command {
 		Use:   "list",
 		Short: "List coverage ranges",
 		Run: func(cmd *cobra.Command, args []string) {
-			client := console.NewRemoteFoxgloveClient(
+			client := api.NewRemoteFoxgloveClient(
 				params.baseURL, *params.clientID,
 				params.token,
 				params.userAgent,
@@ -39,7 +39,7 @@ func newListCoverageCommand(params *baseParams) *cobra.Command {
 			format = ResolveFormat(format, isJsonFormat)
 			err = renderList(
 				os.Stdout,
-				&console.CoverageRequest{
+				&api.CoverageRequest{
 					DeviceID:              deviceID,
 					DeviceName:            deviceName,
 					Start:                 startTime,

--- a/foxglove/cmd/devices.go
+++ b/foxglove/cmd/devices.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 	"github.com/foxglove/foxglove-cli/foxglove/util"
 	"github.com/spf13/cobra"
 )
@@ -16,7 +16,7 @@ func newListDevicesCommand(params *baseParams) *cobra.Command {
 		Use:   "list",
 		Short: "List devices registered to your organization",
 		Run: func(cmd *cobra.Command, args []string) {
-			client := console.NewRemoteFoxgloveClient(
+			client := api.NewRemoteFoxgloveClient(
 				params.baseURL, *params.clientID,
 				params.token,
 				params.userAgent,
@@ -24,7 +24,7 @@ func newListDevicesCommand(params *baseParams) *cobra.Command {
 			format = ResolveFormat(format, isJsonFormat)
 			err := renderList(
 				os.Stdout,
-				console.DevicesRequest{},
+				api.DevicesRequest{},
 				client.Devices,
 				format,
 			)
@@ -47,7 +47,7 @@ func newAddDeviceCommand(params *baseParams) *cobra.Command {
 		Use:   "add",
 		Short: "Add a device for your organization",
 		Run: func(cmd *cobra.Command, args []string) {
-			client := console.NewRemoteFoxgloveClient(
+			client := api.NewRemoteFoxgloveClient(
 				params.baseURL, *params.clientID,
 				params.token,
 				params.userAgent,
@@ -62,7 +62,7 @@ func newAddDeviceCommand(params *baseParams) *cobra.Command {
 				dief("Failed to create device: %s", err)
 			}
 
-			resp, err := client.CreateDevice(console.CreateDeviceRequest{
+			resp, err := client.CreateDevice(api.CreateDeviceRequest{
 				Name:       name,
 				Properties: properties,
 			})
@@ -87,7 +87,7 @@ func newEditDeviceCommand(params *baseParams) *cobra.Command {
 		Short: "Edit a device",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			client := console.NewRemoteFoxgloveClient(
+			client := api.NewRemoteFoxgloveClient(
 				params.baseURL, *params.clientID,
 				params.token,
 				params.userAgent,
@@ -99,7 +99,7 @@ func newEditDeviceCommand(params *baseParams) *cobra.Command {
 			}
 
 			nameOrId := args[0]
-			reqBody := console.CreateDeviceRequest{}
+			reqBody := api.CreateDeviceRequest{}
 			if properties == nil && name == "" {
 				dief("Nothing to update")
 			}
@@ -111,7 +111,7 @@ func newEditDeviceCommand(params *baseParams) *cobra.Command {
 				reqBody.Properties = properties
 			}
 
-			resp, err := client.EditDevice(nameOrId, console.CreateDeviceRequest{
+			resp, err := client.EditDevice(nameOrId, api.CreateDeviceRequest{
 				Name:       name,
 				Properties: properties,
 			})

--- a/foxglove/cmd/devices_test.go
+++ b/foxglove/cmd/devices_test.go
@@ -4,24 +4,24 @@ import (
 	"context"
 	"testing"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAddDeviceCommand(t *testing.T) {
 	ctx := context.Background()
-	sv, err := console.NewMockServer(ctx)
+	sv, err := api.NewMockServer(ctx)
 	assert.Nil(t, err)
 
 	t.Run("creates a device", func(t *testing.T) {
-		client := console.NewMockAuthedClient(t, sv.BaseURL())
-		dev, err := client.CreateDevice(console.CreateDeviceRequest{
+		client := api.NewMockAuthedClient(t, sv.BaseURL())
+		dev, err := client.CreateDevice(api.CreateDeviceRequest{
 			Name:       "new-device",
 			Properties: map[string]interface{}{"key": "val"},
 		})
 		assert.Nil(t, err)
 
-		assert.Contains(t, sv.RegisteredDevices(), console.DevicesResponse{
+		assert.Contains(t, sv.RegisteredDevices(), api.DevicesResponse{
 			ID:         dev.ID,
 			Name:       dev.Name,
 			Properties: dev.Properties,
@@ -31,12 +31,12 @@ func TestAddDeviceCommand(t *testing.T) {
 
 func TestEditDeviceCommand(t *testing.T) {
 	ctx := context.Background()
-	sv, err := console.NewMockServer(ctx)
+	sv, err := api.NewMockServer(ctx)
 	assert.Nil(t, err)
 
 	t.Run("creates a device", func(t *testing.T) {
-		client := console.NewMockAuthedClient(t, sv.BaseURL())
-		dev, err := client.EditDevice("test-device", console.CreateDeviceRequest{
+		client := api.NewMockAuthedClient(t, sv.BaseURL())
+		dev, err := client.EditDevice("test-device", api.CreateDeviceRequest{
 			Name:       "new-name",
 			Properties: map[string]interface{}{"key": "val"},
 		})

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 	"github.com/foxglove/foxglove-cli/foxglove/util"
 	"github.com/spf13/cobra"
 )
@@ -18,7 +18,7 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 		Use:   "add",
 		Short: "Add an event",
 		Run: func(cmd *cobra.Command, args []string) {
-			client := console.NewRemoteFoxgloveClient(
+			client := api.NewRemoteFoxgloveClient(
 				params.baseURL, *params.clientID,
 				params.token,
 				params.userAgent,
@@ -33,7 +33,7 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 				}
 				metadata[key] = val
 			}
-			response, err := client.CreateEvent(console.CreateEventRequest{
+			response, err := client.CreateEvent(api.CreateEventRequest{
 				DeviceID: deviceID,
 				Start:    start,
 				End:      end,
@@ -69,7 +69,7 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 		Use:   "list",
 		Short: "List events",
 		Run: func(cmd *cobra.Command, args []string) {
-			client := console.NewRemoteFoxgloveClient(
+			client := api.NewRemoteFoxgloveClient(
 				params.baseURL, *params.clientID,
 				params.token,
 				params.userAgent,
@@ -77,7 +77,7 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 			format = ResolveFormat(format, isJsonFormat)
 			err := renderList(
 				os.Stdout,
-				&console.EventsRequest{
+				&api.EventsRequest{
 					DeviceID:   deviceID,
 					DeviceName: deviceName,
 					SortBy:     sortBy,

--- a/foxglove/cmd/export.go
+++ b/foxglove/cmd/export.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 	"github.com/foxglove/go-rosbag"
 	"github.com/foxglove/go-rosbag/ros1msg"
 	"github.com/foxglove/mcap/go/mcap"
@@ -451,7 +451,7 @@ func doExport(
 	clientID string,
 	bearerToken string,
 	userAgent string,
-	request *console.StreamRequest,
+	request *api.StreamRequest,
 ) error {
 	tmpdir, err := os.MkdirTemp(".", "export")
 	if err != nil {
@@ -769,13 +769,13 @@ func executeExport(
 	clientID string,
 	bearerToken string,
 	userAgent string,
-	request *console.StreamRequest,
+	request *api.StreamRequest,
 ) error {
 	debugf("exporting with request: %+v", request)
 	if !validOutputFormat(request.OutputFormat) {
 		return ErrInvalidFormat
 	}
-	client := console.NewRemoteFoxgloveClient(
+	client := api.NewRemoteFoxgloveClient(
 		baseURL,
 		clientID,
 		bearerToken,
@@ -795,7 +795,7 @@ func executeExport(
 		errs := make(chan error, 1)
 		done := make(chan bool, 1)
 		go func() {
-			err = console.Export(ctx, pipeWriter, client, request)
+			err = api.Export(ctx, pipeWriter, client, request)
 			if err != nil {
 				errs <- err
 				return
@@ -814,7 +814,7 @@ func executeExport(
 			return err
 		}
 	} else {
-		return console.Export(ctx, writer, client, request)
+		return api.Export(ctx, writer, client, request)
 	}
 }
 
@@ -828,7 +828,7 @@ func createStreamRequest(
 	end string,
 	outputFormat string,
 	topicList string,
-) (*console.StreamRequest, error) {
+) (*api.StreamRequest, error) {
 	var startTime, endTime *time.Time
 	if start != "" {
 		start, err := time.Parse(time.RFC3339, start)
@@ -848,7 +848,7 @@ func createStreamRequest(
 
 	topics := strings.FieldsFunc(topicList, func(c rune) bool { return c == ',' })
 
-	request := &console.StreamRequest{
+	request := &api.StreamRequest{
 		RecordingID:  recordingID,
 		Key:          key,
 		ImportID:     importID,

--- a/foxglove/cmd/export_test.go
+++ b/foxglove/cmd/export_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 	"github.com/foxglove/foxglove-cli/foxglove/util"
 	"github.com/foxglove/go-rosbag"
 	"github.com/foxglove/mcap/go/mcap"
@@ -179,9 +179,9 @@ func TestDoExport(t *testing.T) {
 	t.Run("single request success", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
-		sv, err := console.NewMockServer(ctx)
+		sv, err := api.NewMockServer(ctx)
 		assert.Nil(t, err)
-		client := console.NewRemoteFoxgloveClient(sv.BaseURL(), "client-id", "", "test-app")
+		client := api.NewRemoteFoxgloveClient(sv.BaseURL(), "client-id", "", "test-app")
 		token, err := client.SignIn("client-id")
 		assert.Nil(t, err)
 		start, err := time.Parse(time.RFC3339, "2001-01-01T00:00:00Z")
@@ -211,7 +211,7 @@ func TestDoExport(t *testing.T) {
 			"abc",
 			token,
 			"user-agent",
-			&console.StreamRequest{
+			&api.StreamRequest{
 				DeviceID:     "test-device",
 				Start:        &start,
 				End:          &end,
@@ -233,7 +233,7 @@ func TestExportCommand(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
 		buf := &bytes.Buffer{}
-		sv, err := console.NewMockServer(ctx)
+		sv, err := api.NewMockServer(ctx)
 		assert.Nil(t, err)
 		err = executeExport(
 			ctx,
@@ -242,7 +242,7 @@ func TestExportCommand(t *testing.T) {
 			"",
 			"abc",
 			"user-agent",
-			&console.StreamRequest{
+			&api.StreamRequest{
 				DeviceID:     "test-device",
 				Start:        &start,
 				End:          &end,
@@ -250,13 +250,13 @@ func TestExportCommand(t *testing.T) {
 				Topics:       []string{"/diagnostics"},
 			},
 		)
-		assert.ErrorIs(t, err, console.ErrForbidden)
+		assert.ErrorIs(t, err, api.ErrForbidden)
 	})
 	t.Run("returns error on invalid format", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
 		buf := &bytes.Buffer{}
-		sv, err := console.NewMockServer(ctx)
+		sv, err := api.NewMockServer(ctx)
 		assert.Nil(t, err)
 		err = executeExport(
 			ctx,
@@ -265,7 +265,7 @@ func TestExportCommand(t *testing.T) {
 			"",
 			"abc",
 			"user-agent",
-			&console.StreamRequest{
+			&api.StreamRequest{
 				DeviceID:     "test-device",
 				Start:        &start,
 				End:          &end,
@@ -280,9 +280,9 @@ func TestExportCommand(t *testing.T) {
 		err := withStdoutRedirected(buf, func() {
 			ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 			defer cancel()
-			sv, err := console.NewMockServer(ctx)
+			sv, err := api.NewMockServer(ctx)
 			assert.Nil(t, err)
-			client := console.NewRemoteFoxgloveClient(sv.BaseURL(), "client-id", "", "test-app")
+			client := api.NewRemoteFoxgloveClient(sv.BaseURL(), "client-id", "", "test-app")
 			token, err := client.SignIn("client-id")
 			assert.Nil(t, err)
 			err = executeExport(
@@ -292,7 +292,7 @@ func TestExportCommand(t *testing.T) {
 				"abc",
 				token,
 				"user-agent",
-				&console.StreamRequest{
+				&api.StreamRequest{
 					DeviceID:     "test-device",
 					Start:        &start,
 					End:          &end,
@@ -309,9 +309,9 @@ func TestExportCommand(t *testing.T) {
 		buf := &bytes.Buffer{}
 		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
-		sv, err := console.NewMockServer(ctx)
+		sv, err := api.NewMockServer(ctx)
 		assert.Nil(t, err)
-		client := console.NewRemoteFoxgloveClient(sv.BaseURL(), "client-id", "", "test-app")
+		client := api.NewRemoteFoxgloveClient(sv.BaseURL(), "client-id", "", "test-app")
 		token, err := client.SignIn("client-id")
 		assert.Nil(t, err)
 		clientID := "client-id"
@@ -337,7 +337,7 @@ func TestExportCommand(t *testing.T) {
 				"abc",
 				token,
 				"user-agent",
-				&console.StreamRequest{
+				&api.StreamRequest{
 					DeviceID:     "test-device",
 					Start:        &start,
 					End:          &end,
@@ -354,9 +354,9 @@ func TestExportCommand(t *testing.T) {
 		buf := &bytes.Buffer{}
 		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
-		sv, err := console.NewMockServer(ctx)
+		sv, err := api.NewMockServer(ctx)
 		assert.Nil(t, err)
-		client := console.NewRemoteFoxgloveClient(sv.BaseURL(), "client-id", "", "test-app")
+		client := api.NewRemoteFoxgloveClient(sv.BaseURL(), "client-id", "", "test-app")
 		token, err := client.SignIn("client-id")
 		assert.Nil(t, err)
 		clientID := "client-id"
@@ -382,7 +382,7 @@ func TestExportCommand(t *testing.T) {
 				"abc",
 				token,
 				"user-agent",
-				&console.StreamRequest{
+				&api.StreamRequest{
 					DeviceID:     "test-device",
 					Start:        &start,
 					End:          &end,

--- a/foxglove/cmd/extensions.go
+++ b/foxglove/cmd/extensions.go
@@ -5,16 +5,16 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 	"github.com/spf13/cobra"
 )
 
-func executeExtensionUpload(client *console.FoxgloveClient, filename string) error {
+func executeExtensionUpload(client *api.FoxgloveClient, filename string) error {
 	ctx := context.Background()
-	return console.UploadExtensionFile(ctx, client, filename)
+	return api.UploadExtensionFile(ctx, client, filename)
 }
 
-func executeExtensionDelete(client *console.FoxgloveClient, extensionId string) error {
+func executeExtensionDelete(client *api.FoxgloveClient, extensionId string) error {
 	return client.DeleteExtension(extensionId)
 }
 
@@ -25,7 +25,7 @@ func newPublishExtensionCommand(params *baseParams) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			filename := args[0] // guaranteed length 1 due to Args setting above
-			client := console.NewRemoteFoxgloveClient(
+			client := api.NewRemoteFoxgloveClient(
 				params.baseURL,
 				*params.clientID,
 				params.token,
@@ -52,7 +52,7 @@ func newListExtensionsCommand(params *baseParams) *cobra.Command {
 		Use:   "list",
 		Short: "List Studio extensions created for your organization",
 		Run: func(cmd *cobra.Command, args []string) {
-			client := console.NewRemoteFoxgloveClient(
+			client := api.NewRemoteFoxgloveClient(
 				params.baseURL, *params.clientID,
 				params.token,
 				params.userAgent,
@@ -60,7 +60,7 @@ func newListExtensionsCommand(params *baseParams) *cobra.Command {
 			format = ResolveFormat(format, isJsonFormat)
 			err := renderList(
 				os.Stdout,
-				console.ExtensionsRequest{},
+				api.ExtensionsRequest{},
 				client.Extensions,
 				format,
 			)
@@ -82,7 +82,7 @@ func newUnpublishExtensionCommand(params *baseParams) *cobra.Command {
 		Short: "Delete and unpublish a Studio extension from your organization",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			client := console.NewRemoteFoxgloveClient(
+			client := api.NewRemoteFoxgloveClient(
 				params.baseURL, *params.clientID,
 				params.token,
 				params.userAgent,

--- a/foxglove/cmd/extensions_test.go
+++ b/foxglove/cmd/extensions_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,23 +14,23 @@ func TestPublishExtensionCommand(t *testing.T) {
 	t.Run("returns forbidden if not authenticated", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
-		sv, err := console.NewMockServer(ctx)
+		sv, err := api.NewMockServer(ctx)
 		assert.Nil(t, err)
-		client := console.NewRemoteFoxgloveClient(
+		client := api.NewRemoteFoxgloveClient(
 			sv.BaseURL(),
 			"client",
 			"token",
 			"user-agent",
 		)
 		err = executeExtensionUpload(client, "../testdata/fg.mock-0.0.0.foxe")
-		assert.ErrorIs(t, err, console.ErrForbidden)
+		assert.ErrorIs(t, err, api.ErrForbidden)
 	})
 	t.Run("returns friendly error for unexpected file extension", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
-		sv, err := console.NewMockServer(ctx)
+		sv, err := api.NewMockServer(ctx)
 		assert.Nil(t, err)
-		client := console.NewRemoteFoxgloveClient(
+		client := api.NewRemoteFoxgloveClient(
 			sv.BaseURL(),
 			"client",
 			"token",
@@ -44,9 +44,9 @@ func TestPublishExtensionCommand(t *testing.T) {
 func TestUnpublishExtensionCommand(t *testing.T) {
 	ctx := context.Background()
 	t.Run("returns ok if deleted", func(t *testing.T) {
-		sv, err := console.NewMockServer(ctx)
+		sv, err := api.NewMockServer(ctx)
 		assert.Nil(t, err)
-		client := console.NewMockAuthedClient(t, sv.BaseURL())
+		client := api.NewMockAuthedClient(t, sv.BaseURL())
 		err = executeExtensionDelete(
 			client,
 			sv.ValidExtensionId(),
@@ -54,9 +54,9 @@ func TestUnpublishExtensionCommand(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("does not error if extension not found", func(t *testing.T) {
-		sv, err := console.NewMockServer(ctx)
+		sv, err := api.NewMockServer(ctx)
 		assert.Nil(t, err)
-		client := console.NewMockAuthedClient(t, sv.BaseURL())
+		client := api.NewMockAuthedClient(t, sv.BaseURL())
 		err = executeExtensionDelete(
 			client,
 			"nonexistent-extension-id",

--- a/foxglove/cmd/import.go
+++ b/foxglove/cmd/import.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -21,8 +21,8 @@ func executeImport(baseURL, clientID, deviceID, deviceName, key, filename, token
 	if err != nil {
 		return err
 	}
-	client := console.NewRemoteFoxgloveClient(baseURL, clientID, token, userAgent)
-	err = console.Import(ctx, client, deviceID, deviceName, key, filename)
+	client := api.NewRemoteFoxgloveClient(baseURL, clientID, token, userAgent)
+	err = api.Import(ctx, client, deviceID, deviceName, key, filename)
 	if err != nil {
 		return err
 	}
@@ -31,12 +31,12 @@ func executeImport(baseURL, clientID, deviceID, deviceName, key, filename, token
 }
 
 func importFromEdge(baseURL, clientID, token, userAgent, edgeRecordingID string) error {
-	client := console.NewRemoteFoxgloveClient(
+	client := api.NewRemoteFoxgloveClient(
 		baseURL, clientID,
 		token,
 		userAgent,
 	)
-	_, err := client.ImportFromEdge(console.ImportFromEdgeRequest{}, edgeRecordingID)
+	_, err := client.ImportFromEdge(api.ImportFromEdgeRequest{}, edgeRecordingID)
 	if err != nil {
 		return err
 	}

--- a/foxglove/cmd/import_test.go
+++ b/foxglove/cmd/import_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,7 +14,7 @@ func TestImportCommand(t *testing.T) {
 	t.Run("returns forbidden if not authenticated", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
-		sv, err := console.NewMockServer(ctx)
+		sv, err := api.NewMockServer(ctx)
 		assert.Nil(t, err)
 		err = executeImport(
 			sv.BaseURL(),
@@ -26,14 +26,14 @@ func TestImportCommand(t *testing.T) {
 			"",
 			"user-agent",
 		)
-		assert.ErrorIs(t, err, console.ErrForbidden)
+		assert.ErrorIs(t, err, api.ErrForbidden)
 	})
 	t.Run("returns friendly message when device is not registered", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
-		sv, err := console.NewMockServer(ctx)
+		sv, err := api.NewMockServer(ctx)
 		assert.Nil(t, err)
-		client := console.NewRemoteFoxgloveClient(sv.BaseURL(), "client-id", "", "test-app")
+		client := api.NewRemoteFoxgloveClient(sv.BaseURL(), "client-id", "", "test-app")
 		token, err := client.SignIn("client-id")
 		assert.Nil(t, err)
 		err = executeImport(

--- a/foxglove/cmd/imports.go
+++ b/foxglove/cmd/imports.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +21,7 @@ func newListImportsCommand(params *baseParams) *cobra.Command {
 		Use:   "list",
 		Short: "List imports for a device",
 		Run: func(cmd *cobra.Command, args []string) {
-			client := console.NewRemoteFoxgloveClient(
+			client := api.NewRemoteFoxgloveClient(
 				params.baseURL, *params.clientID,
 				params.token,
 				params.userAgent,
@@ -45,7 +45,7 @@ func newListImportsCommand(params *baseParams) *cobra.Command {
 			format = ResolveFormat(format, isJsonFormat)
 			err = renderList(
 				os.Stdout,
-				&console.ImportsRequest{
+				&api.ImportsRequest{
 					DeviceID:       deviceID,
 					Start:          startTime,
 					End:            endTime,

--- a/foxglove/cmd/info.go
+++ b/foxglove/cmd/info.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 	tw "github.com/foxglove/foxglove-cli/foxglove/util/tablewriter"
 
 	"github.com/spf13/cobra"
@@ -18,7 +18,7 @@ func executeInfo(baseURL, clientID, token, userAgent string) error {
 		return nil
 	}
 
-	client := console.NewRemoteFoxgloveClient(baseURL, clientID, token, userAgent)
+	client := api.NewRemoteFoxgloveClient(baseURL, clientID, token, userAgent)
 	me, err := client.Me()
 	if err != nil {
 		return err

--- a/foxglove/cmd/login.go
+++ b/foxglove/cmd/login.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 
 	"github.com/spf13/cobra"
 )
 
-func executeLogin(baseURL, clientID, userAgent string, authDelegate console.AuthDelegate) error {
+func executeLogin(baseURL, clientID, userAgent string, authDelegate api.AuthDelegate) error {
 	ctx := context.Background()
-	client := console.NewRemoteFoxgloveClient(baseURL, clientID, "", userAgent)
-	bearerToken, err := console.Login(ctx, client, authDelegate)
+	client := api.NewRemoteFoxgloveClient(baseURL, clientID, "", userAgent)
+	bearerToken, err := api.Login(ctx, client, authDelegate)
 	if err != nil {
 		return err
 	}
@@ -29,13 +29,13 @@ func newLoginCommand(params *baseParams) *cobra.Command {
 		Use:   "login",
 		Short: "Log in to Foxglove Data Platform",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := executeLogin(baseURL, *params.clientID, params.userAgent, &console.PlatformAuthDelegate{})
+			err := executeLogin(baseURL, *params.clientID, params.userAgent, &api.PlatformAuthDelegate{})
 			if err != nil {
 				dief("Login failed: %s", err)
 			}
 		},
 	}
 	loginCmd.InheritedFlags()
-	loginCmd.PersistentFlags().StringVarP(&baseURL, "base-url", "", defaultBaseURL, "console API server")
+	loginCmd.PersistentFlags().StringVarP(&baseURL, "base-url", "", defaultBaseURL, "API server")
 	return loginCmd
 }

--- a/foxglove/cmd/login_test.go
+++ b/foxglove/cmd/login_test.go
@@ -5,19 +5,19 @@ import (
 	"os"
 	"testing"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 )
 
 func TestLoginCommand(t *testing.T) {
 	ctx := context.Background()
-	sv, err := console.NewMockServer(ctx)
+	sv, err := api.NewMockServer(ctx)
 	assert.Nil(t, err)
 	configfile := "./test-config.yaml"
 	err = initConfig(&configfile)
 	assert.Nil(t, err)
-	err = executeLogin(sv.BaseURL(), "client-id", "test-app", &console.MockAuthDelegate{})
+	err = executeLogin(sv.BaseURL(), "client-id", "test-app", &api.MockAuthDelegate{})
 	assert.Nil(t, err)
 	assert.NotEmpty(t, sv.BearerTokens)
 	m := make(map[string]string)

--- a/foxglove/cmd/pending_imports.go
+++ b/foxglove/cmd/pending_imports.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 	"github.com/spf13/cobra"
 )
 
@@ -24,7 +24,7 @@ func newPendingImportsCommand(params *baseParams) *cobra.Command {
 		Use:   "list",
 		Short: "List the pending and errored import jobs for uploaded recordings",
 		Run: func(cmd *cobra.Command, args []string) {
-			client := console.NewRemoteFoxgloveClient(
+			client := api.NewRemoteFoxgloveClient(
 				params.baseURL, *params.clientID,
 				params.token,
 				params.userAgent,
@@ -37,7 +37,7 @@ func newPendingImportsCommand(params *baseParams) *cobra.Command {
 			format = ResolveFormat(format, isJsonFormat)
 			err = renderList(
 				os.Stdout,
-				console.PendingImportsRequest{
+				api.PendingImportsRequest{
 					RequestId:       requestId,
 					DeviceId:        deviceId,
 					DeviceName:      deviceName,

--- a/foxglove/cmd/recordings.go
+++ b/foxglove/cmd/recordings.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 	"github.com/spf13/cobra"
 )
 
@@ -27,7 +27,7 @@ func newListRecordingsCommand(params *baseParams) *cobra.Command {
 		Use:   "list",
 		Short: "List recordings",
 		Run: func(cmd *cobra.Command, args []string) {
-			client := console.NewRemoteFoxgloveClient(
+			client := api.NewRemoteFoxgloveClient(
 				params.baseURL, *params.clientID,
 				params.token,
 				params.userAgent,
@@ -43,7 +43,7 @@ func newListRecordingsCommand(params *baseParams) *cobra.Command {
 			format = ResolveFormat(format, isJsonFormat)
 			err = renderList(
 				os.Stdout,
-				&console.RecordingsRequest{
+				&api.RecordingsRequest{
 					DeviceID:     deviceID,
 					DeviceName:   deviceName,
 					Start:        startTime,
@@ -91,7 +91,7 @@ func newDeleteRecordingCommand(params *baseParams) *cobra.Command {
 		Short: "Delete a recording from your organization",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			client := console.NewRemoteFoxgloveClient(params.baseURL, *params.clientID, params.token, params.userAgent)
+			client := api.NewRemoteFoxgloveClient(params.baseURL, *params.clientID, params.token, params.userAgent)
 			if err := client.DeleteRecording(args[0]); err != nil {
 				dief("Failed to delete recording: %s", err)
 			}

--- a/foxglove/cmd/root.go
+++ b/foxglove/cmd/root.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 	"github.com/spf13/cobra"
 
 	"github.com/spf13/viper"
@@ -70,8 +70,8 @@ func listDevicesAutocompletionFunc(
 	userAgent string,
 ) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		client := console.NewRemoteFoxgloveClient(baseURL, clientID, token, userAgent)
-		devices, err := client.Devices(console.DevicesRequest{})
+		client := api.NewRemoteFoxgloveClient(baseURL, clientID, token, userAgent)
+		devices, err := client.Devices(api.DevicesRequest{})
 		if err != nil {
 			return []string{}, cobra.ShellCompDirectiveDefault
 		}
@@ -90,8 +90,8 @@ func listDevicesByNameAutocompletionFunc(
 	userAgent string,
 ) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		client := console.NewRemoteFoxgloveClient(baseURL, clientID, token, userAgent)
-		devices, err := client.Devices(console.DevicesRequest{})
+		client := api.NewRemoteFoxgloveClient(baseURL, clientID, token, userAgent)
+		devices, err := client.Devices(api.DevicesRequest{})
 		if err != nil {
 			return []string{}, cobra.ShellCompDirectiveDefault
 		}

--- a/foxglove/cmd/utils.go
+++ b/foxglove/cmd/utils.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 	tw "github.com/foxglove/foxglove-cli/foxglove/util/tablewriter"
 	"github.com/foxglove/mcap/go/mcap"
 	"github.com/relvacode/iso8601"
@@ -81,7 +81,7 @@ func validateImportLooksLegal(r io.ReadSeeker) error {
 	return ErrInvalidInput
 }
 
-func renderList[RequestType console.Request, ResponseType console.Record](
+func renderList[RequestType api.Request, ResponseType api.Record](
 	w io.Writer,
 	req RequestType,
 	fn func(RequestType) ([]ResponseType, error),
@@ -118,13 +118,13 @@ func renderList[RequestType console.Request, ResponseType console.Record](
 	return nil
 }
 
-func renderJSON[RecordType console.Record](w io.Writer, records []RecordType) error {
+func renderJSON[RecordType api.Record](w io.Writer, records []RecordType) error {
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", "    ")
 	return encoder.Encode(records)
 }
 
-func renderCSV[RecordType console.Record](w io.Writer, records []RecordType) error {
+func renderCSV[RecordType api.Record](w io.Writer, records []RecordType) error {
 	writer := csv.NewWriter(w)
 	err := writer.Write(records[0].Headers())
 	if err != nil {

--- a/foxglove/util/custom_properties.go
+++ b/foxglove/util/custom_properties.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 )
 
 type OrgCustomProperties map[string]PropertyDefinition
@@ -17,7 +17,7 @@ type PropertyDefinition struct {
 
 // Validate CLI properties input & convert to args for a device request.
 // This requires downloading the available properties for the org.
-func DeviceProperties(propertyPairs []string, client *console.FoxgloveClient) (map[string]interface{}, error) {
+func DeviceProperties(propertyPairs []string, client *api.FoxgloveClient) (map[string]interface{}, error) {
 	if len(propertyPairs) == 0 {
 		return nil, nil
 	}
@@ -66,8 +66,8 @@ func DeviceProperties(propertyPairs []string, client *console.FoxgloveClient) (m
 }
 
 // Download device custom properties and convert to a lookup map
-func fetchAvailableProperties(client *console.FoxgloveClient) (OrgCustomProperties, error) {
-	propertiesResp, err := client.DeviceCustomProperties(console.CustomPropertiesRequest{
+func fetchAvailableProperties(client *api.FoxgloveClient) (OrgCustomProperties, error) {
+	propertiesResp, err := client.DeviceCustomProperties(api.CustomPropertiesRequest{
 		ResourceType: "device",
 	})
 	if err != nil {

--- a/foxglove/util/custom_properties_test.go
+++ b/foxglove/util/custom_properties_test.go
@@ -5,15 +5,15 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/foxglove/foxglove-cli/foxglove/console"
+	"github.com/foxglove/foxglove-cli/foxglove/api"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDeviceProperties(t *testing.T) {
 	ctx := context.Background()
-	sv, err := console.NewMockServer(ctx)
+	sv, err := api.NewMockServer(ctx)
 	assert.Nil(t, err)
-	propertyOfType := func(valueType string) *console.CustomPropertiesResponseItem {
+	propertyOfType := func(valueType string) *api.CustomPropertiesResponseItem {
 		for _, prop := range sv.RegisteredProperties() {
 			if prop.ValueType == valueType {
 				return &prop
@@ -65,8 +65,8 @@ func TestDeviceProperties(t *testing.T) {
 	})
 }
 
-func newAuthedClient(t *testing.T, baseUrl string) *console.FoxgloveClient {
-	client := console.NewRemoteFoxgloveClient(
+func newAuthedClient(t *testing.T, baseUrl string) *api.FoxgloveClient {
+	client := api.NewRemoteFoxgloveClient(
 		baseUrl,
 		"client",
 		"",
@@ -74,7 +74,7 @@ func newAuthedClient(t *testing.T, baseUrl string) *console.FoxgloveClient {
 	)
 	token, err := client.SignIn("client-id")
 	assert.Nil(t, err)
-	return console.NewRemoteFoxgloveClient(
+	return api.NewRemoteFoxgloveClient(
 		baseUrl,
 		"client",
 		token,


### PR DESCRIPTION
### Changelog
None

### Description
_console_ is no longer a thing. Even when it was a thing, console referred to the "UI" and it was incorrect to refer to the "api" as console. This resolves this inconsistency by renaming the "console" folder to "api".