### PR TITLE
error if multiple files are supplied to import command

### DIFF
--- a/foxglove/cmd/import.go
+++ b/foxglove/cmd/import.go
@@ -52,6 +52,7 @@ func newImportCommand(params *baseParams, commandName string) (*cobra.Command, e
 	importCmd := &cobra.Command{
 		Use:   fmt.Sprintf("%s [FILE]", commandName),
 		Short: "Import a data file to Foxglove Data Platform",
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			if edgeRecordingID != "" {
 				err := importFromEdge(params.baseURL, *params.clientID, params.token, params.userAgent, edgeRecordingID)
@@ -61,12 +62,6 @@ func newImportCommand(params *baseParams, commandName string) (*cobra.Command, e
 				return
 			}
 
-			if len(args) == 0 {
-				dief("Filename not specified")
-			}
-			if len(args) > 1 {
-				dief("Only one filename can be specified")
-			}
 			filename := args[0]
 			err := executeImport(
 				params.baseURL,

--- a/foxglove/cmd/import.go
+++ b/foxglove/cmd/import.go
@@ -64,6 +64,9 @@ func newImportCommand(params *baseParams, commandName string) (*cobra.Command, e
 			if len(args) == 0 {
 				dief("Filename not specified")
 			}
+			if len(args) > 1 {
+				dief("Only one filename can be specified")
+			}
 			filename := args[0]
 			err := executeImport(
 				params.baseURL,


### PR DESCRIPTION
### Changelog
Correctly error when multiple files are supplied to the `import` command.

### Docs
None

### Description
Only one file can be imported at a time per command invocation. Explicitly reject multiple arguments.
<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->
Fixes: FG-8204

