### PR TITLE
Add key to pending imports

### DIFF
--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -526,7 +526,7 @@ func (e ExtensionResponse) String() string {
 
 type PendingImportsRequest struct {
 	RequestId       string `json:"requestId" form:"requestId,omitempty"`
-	Key		string `json:"key" form:"key,omitempty"`
+	Key		        string `json:"key" form:"key,omitempty"`
 	DeviceId        string `json:"device.id" form:"device.id,omitempty"`
 	DeviceName      string `json:"device.name" form:"device.name,omitempty"`
 	Error           string `json:"error" form:"error,omitempty"`

--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -526,6 +526,7 @@ func (e ExtensionResponse) String() string {
 
 type PendingImportsRequest struct {
 	RequestId       string `json:"requestId" form:"requestId,omitempty"`
+	Key		string `json:"key" form:"key,omitempty"`
 	DeviceId        string `json:"device.id" form:"device.id,omitempty"`
 	DeviceName      string `json:"device.name" form:"device.name,omitempty"`
 	Error           string `json:"error" form:"error,omitempty"`

--- a/foxglove/cmd/pending_imports.go
+++ b/foxglove/cmd/pending_imports.go
@@ -47,7 +47,7 @@ func newPendingImportsCommand(params *baseParams) *cobra.Command {
 				os.Stdout,
 				api.PendingImportsRequest{
 					RequestId:       requestId,
-					Key:		 key,
+					Key:		     key,
 					DeviceId:        deviceId,
 					DeviceName:      deviceName,
 					Error:           error,

--- a/foxglove/cmd/pending_imports.go
+++ b/foxglove/cmd/pending_imports.go
@@ -12,6 +12,7 @@ import (
 func newPendingImportsCommand(params *baseParams) *cobra.Command {
 	var format string
 	var requestId string
+	var key string
 	var deviceId string
 	var deviceName string
 	var filename string
@@ -46,6 +47,7 @@ func newPendingImportsCommand(params *baseParams) *cobra.Command {
 				os.Stdout,
 				api.PendingImportsRequest{
 					RequestId:       requestId,
+					Key:		 key,
 					DeviceId:        deviceId,
 					DeviceName:      deviceName,
 					Error:           error,
@@ -70,6 +72,7 @@ func newPendingImportsCommand(params *baseParams) *cobra.Command {
 	pendingImportsCmd.PersistentFlags().StringVarP(&projectID, "project-id", "", viper.GetString("default_project_id"), "Project ID")
 	pendingImportsCmd.PersistentFlags().BoolVarP(&withoutProject, "without-project", "", false, "Filter to pending imports without a project")
 	pendingImportsCmd.PersistentFlags().StringVarP(&requestId, "request-id", "", "", "Request ID")
+	pendingImportsCmd.PersistentFlags().StringVarP(&key, "key", "", "", "Key")
 	pendingImportsCmd.PersistentFlags().StringVarP(&deviceId, "device-id", "", "", "Device ID")
 	pendingImportsCmd.PersistentFlags().StringVarP(&deviceName, "device-name", "", "", "Device name")
 	pendingImportsCmd.PersistentFlags().StringVarP(&filename, "filename", "", "", "Filename")


### PR DESCRIPTION
Added the `--key` option to the `pending-imports list` command

This extends the `pending-imports` command to add the `key` query parameter in the API documented here:
https://docs.foxglove.dev/api#tag/Recordings/paths/~1data~1pending-imports/get

Manually tested as follows:
```
$ ./foxglove pending-imports list --show-completed --key=cmansley_1006ca0c1c
|      Created at      |      Updated at      |                Org ID                |                                                                    Filename                                                                    |  Pipeline stage  |                Request ID                |  Device ID  |  Device name  |       Import ID       |      Site ID      |      Project ID      |  Status  |  Error  |
|----------------------|----------------------|--------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|------------------|------------------------------------------|-------------|---------------|-----------------------|-------------------|----------------------|----------|---------|
| 2025-10-06T19:01:38Z | 2025-10-06T19:02:18Z | 00dad175-dcaa-40f3-ba3e-9889e5976ed9 | deviceless/org_id=00dad175-dcaa-40f3-ba3e-9889e5976ed9/key=cmansley_1006ca0c1c/request_id=149dcba1-b9c0-4cac-a4c9-0a4230c78b30/lidar_tmp.mcap  | indexing         | 6d75ae88c488478c88658ee93f616c65c724a878 |             |               | imp_0dwJPSTqIczIxSng  | GJGVyTJyWRK9YXBt  | prj_0dX17nGR9ift1zSs | complete |         |
```
