### PR TITLE
update event filters and add event type support to CLI

### DIFF
--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -369,7 +369,8 @@ type EventsRequest struct {
 	Start       string `json:"start" form:"start,omitempty"`
 	End         string `json:"end" form:"end,omitempty"`
 	Query       string `json:"key" form:"query,omitempty"`
-	EventTypeID string `json:"eventTypeId" form:"eventTypeId,omitempty"`
+	EventTypeID string   `json:"eventTypeId" form:"eventTypeId,omitempty"`
+	QueryFields []string `json:"queryFields" form:"queryFields,omitempty"`
 }
 
 type EventTypeSummary struct {

--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -366,7 +366,7 @@ type EventsRequest struct {
 	EventTypeID string   `json:"eventTypeId" form:"eventTypeId,omitempty"`
 	Limit       int      `json:"limit" form:"limit,omitempty"`
 	Offset      int      `json:"offset" form:"offset,omitempty"`
-	Query       string   `json:"key" form:"query,omitempty"`
+	Query       string   `json:"query" form:"query,omitempty"`
 	QueryFields []string `json:"queryFields" form:"queryFields,omitempty"`
 	SortBy      string   `json:"sortBy" form:"sortBy,omitempty"`
 	SortOrder   string   `json:"sortOrder" form:"sortOrder,omitempty"`
@@ -589,12 +589,11 @@ type PatchSessionRecordingsRequest struct {
 }
 
 type CreateEventRequest struct {
-	DeviceID    string                 `json:"deviceId"`
-	End         string                 `json:"end"`
-	EventTypeID string                 `json:"eventTypeId,omitempty"`
-	Metadata    map[string]string      `json:"metadata"`
-	Properties  map[string]interface{} `json:"properties,omitempty"`
-	Start       string                 `json:"start"`
+	DeviceID    string            `json:"deviceId"`
+	End         string            `json:"end"`
+	EventTypeID string            `json:"eventTypeId,omitempty"`
+	Metadata    map[string]string `json:"metadata"`
+	Start       string            `json:"start"`
 }
 
 type CreateEventResponse = EventResponseItem

--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -360,17 +360,17 @@ func (r ImportsResponse) Headers() []string {
 }
 
 type EventsRequest struct {
-	DeviceID    string `json:"device.id" form:"device.id,omitempty"`
-	DeviceName  string `json:"device.name" form:"device.name,omitempty"`
-	SortBy      string `json:"sortBy" form:"sortBy,omitempty"`
-	SortOrder   string `json:"sortOrder" form:"sortOrder,omitempty"`
-	Limit       int    `json:"limit" form:"limit,omitempty"`
-	Offset      int    `json:"offset" form:"offset,omitempty"`
-	Start       string `json:"start" form:"start,omitempty"`
-	End         string `json:"end" form:"end,omitempty"`
-	Query       string `json:"key" form:"query,omitempty"`
+	DeviceID    string   `json:"device.id" form:"device.id,omitempty"`
+	DeviceName  string   `json:"device.name" form:"device.name,omitempty"`
+	End         string   `json:"end" form:"end,omitempty"`
 	EventTypeID string   `json:"eventTypeId" form:"eventTypeId,omitempty"`
+	Limit       int      `json:"limit" form:"limit,omitempty"`
+	Offset      int      `json:"offset" form:"offset,omitempty"`
+	Query       string   `json:"key" form:"query,omitempty"`
 	QueryFields []string `json:"queryFields" form:"queryFields,omitempty"`
+	SortBy      string   `json:"sortBy" form:"sortBy,omitempty"`
+	SortOrder   string   `json:"sortOrder" form:"sortOrder,omitempty"`
+	Start       string   `json:"start" form:"start,omitempty"`
 }
 
 type EventTypeSummary struct {
@@ -379,15 +379,15 @@ type EventTypeSummary struct {
 }
 
 type EventResponseItem struct {
-	ID          string                 `json:"id"`
+	CreatedAt   string                 `json:"createdAt"`
 	Device      DeviceSummary          `json:"device"`
-	Start       string                 `json:"start"`
 	End         string                 `json:"end"`
-	Metadata    map[string]string      `json:"metadata"`
-	Properties  map[string]interface{} `json:"properties"`
 	EventType   *EventTypeSummary      `json:"eventType"`
 	EventTypeID string                 `json:"eventTypeId"`
-	CreatedAt   string                 `json:"createdAt"`
+	ID          string                 `json:"id"`
+	Metadata    map[string]string      `json:"metadata"`
+	Properties  map[string]interface{} `json:"properties"`
+	Start       string                 `json:"start"`
 	UpdatedAt   string                 `json:"updatedAt"`
 }
 
@@ -397,11 +397,8 @@ func (r EventResponseItem) Fields() []string {
 	eventType := ""
 	if r.EventType != nil && r.EventType.ID != "" {
 		eventType = r.EventType.Name + " (" + r.EventType.ID + ")"
-	} else if r.EventType != nil {
-		eventType = r.EventType.Name
-	} else if r.EventTypeID != "" {
-		eventType = r.EventTypeID
 	}
+
 	return []string{
 		r.ID,
 		r.Device.ID,
@@ -604,11 +601,11 @@ type PatchSessionRecordingsRequest struct {
 
 type CreateEventRequest struct {
 	DeviceID    string                 `json:"deviceId"`
-	Start       string                 `json:"start"`
 	End         string                 `json:"end"`
+	EventTypeID string                 `json:"eventTypeId,omitempty"`
 	Metadata    map[string]string      `json:"metadata"`
 	Properties  map[string]interface{} `json:"properties,omitempty"`
-	EventTypeID string                 `json:"eventTypeId,omitempty"`
+	Start       string                 `json:"start"`
 }
 
 type CreateEventResponse = EventResponseItem
@@ -618,18 +615,18 @@ type EventTypesRequest struct{}
 type EventTypePropertyDefinition struct {
 	Key       string   `json:"key"`
 	Label     string   `json:"label"`
-	ValueType string   `json:"valueType"`
 	Required  bool     `json:"required"`
 	Values    []string `json:"values,omitempty"`
+	ValueType string   `json:"valueType"`
 }
 
 type EventTypeResponse struct {
-	ID         string                         `json:"id"`
-	Name       string                         `json:"name"`
-	ColorName  string                         `json:"colorName"`
-	Properties []EventTypePropertyDefinition  `json:"properties"`
-	CreatedAt  string                         `json:"createdAt"`
-	UpdatedAt  string                         `json:"updatedAt"`
+	ColorName  string                        `json:"colorName"`
+	CreatedAt  string                        `json:"createdAt"`
+	ID         string                        `json:"id"`
+	Name       string                        `json:"name"`
+	Properties []EventTypePropertyDefinition `json:"properties"`
+	UpdatedAt  string                        `json:"updatedAt"`
 }
 
 func (r EventTypeResponse) Fields() []string {

--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -360,38 +360,59 @@ func (r ImportsResponse) Headers() []string {
 }
 
 type EventsRequest struct {
-	DeviceID   string `json:"device.id" form:"device.id,omitempty"`
-	DeviceName string `json:"device.name" form:"device.name,omitempty"`
-	SortBy     string `json:"sortBy" form:"sortBy,omitempty"`
-	SortOrder  string `json:"sortOrder" form:"sortOrder,omitempty"`
-	Limit      int    `json:"limit" form:"limit,omitempty"`
-	Offset     int    `json:"offset" form:"offset,omitempty"`
-	Start      string `json:"start" form:"start,omitempty"`
-	End        string `json:"end" form:"end,omitempty"`
-	Query      string `json:"key" form:"query,omitempty"`
+	DeviceID    string `json:"device.id" form:"device.id,omitempty"`
+	DeviceName  string `json:"device.name" form:"device.name,omitempty"`
+	SortBy      string `json:"sortBy" form:"sortBy,omitempty"`
+	SortOrder   string `json:"sortOrder" form:"sortOrder,omitempty"`
+	Limit       int    `json:"limit" form:"limit,omitempty"`
+	Offset      int    `json:"offset" form:"offset,omitempty"`
+	Start       string `json:"start" form:"start,omitempty"`
+	End         string `json:"end" form:"end,omitempty"`
+	Query       string `json:"key" form:"query,omitempty"`
+	EventTypeID string `json:"eventTypeId" form:"eventTypeId,omitempty"`
+}
+
+type EventTypeSummary struct {
+	Name string `json:"name"`
+	ID   string `json:"id"`
 }
 
 type EventResponseItem struct {
-	ID        string            `json:"id"`
-	Device    DeviceSummary     `json:"device"`
-	Start     string            `json:"start"`
-	End       string            `json:"end"`
-	Metadata  map[string]string `json:"metadata"`
-	CreatedAt string            `json:"createdAt"`
-	UpdatedAt string            `json:"updatedAt"`
+	ID          string                 `json:"id"`
+	Device      DeviceSummary          `json:"device"`
+	Start       string                 `json:"start"`
+	End         string                 `json:"end"`
+	Metadata    map[string]string      `json:"metadata"`
+	Properties  map[string]interface{} `json:"properties"`
+	EventType   *EventTypeSummary      `json:"eventType"`
+	EventTypeID string                 `json:"eventTypeId"`
+	CreatedAt   string                 `json:"createdAt"`
+	UpdatedAt   string                 `json:"updatedAt"`
 }
 
 func (r EventResponseItem) Fields() []string {
 	metadata, _ := json.Marshal(r.Metadata)
+	properties, _ := json.Marshal(r.Properties)
+	eventType := ""
+	if r.EventType != nil {
+		eventType = r.EventType.Name
+		if r.EventType.ID != "" {
+			eventType = r.EventType.Name + " (" + r.EventType.ID + ")"
+		}
+	} else if r.EventTypeID != "" {
+		eventType = r.EventTypeID
+	}
 	return []string{
 		r.ID,
 		r.Device.ID,
 		r.Device.Name,
 		r.Start,
 		r.End,
+		eventType,
 		r.CreatedAt,
 		r.UpdatedAt,
 		string(metadata),
+		string(properties),
 	}
 }
 
@@ -402,9 +423,11 @@ func (r EventResponseItem) Headers() []string {
 		"Device Name",
 		"Start",
 		"End",
+		"Event Type",
 		"Created At",
 		"Updated At",
 		"Metadata",
+		"Properties",
 	}
 }
 
@@ -580,13 +603,57 @@ type PatchSessionRecordingsRequest struct {
 }
 
 type CreateEventRequest struct {
-	DeviceID string            `json:"deviceId"`
-	Start    string            `json:"start"`
-	End      string            `json:"end"`
-	Metadata map[string]string `json:"metadata"`
+	DeviceID    string                 `json:"deviceId"`
+	Start       string                 `json:"start"`
+	End         string                 `json:"end"`
+	Metadata    map[string]string      `json:"metadata,omitempty"`
+	Properties  map[string]interface{} `json:"properties,omitempty"`
+	EventTypeID string                 `json:"eventTypeId,omitempty"`
 }
 
 type CreateEventResponse = EventResponseItem
+
+type EventTypesRequest struct{}
+
+type EventTypePropertyDefinition struct {
+	Key       string   `json:"key"`
+	Label     string   `json:"label"`
+	ValueType string   `json:"valueType"`
+	Required  bool     `json:"required"`
+	Values    []string `json:"values,omitempty"`
+}
+
+type EventTypeResponse struct {
+	ID         string                         `json:"id"`
+	Name       string                         `json:"name"`
+	ColorName  string                         `json:"colorName"`
+	Properties []EventTypePropertyDefinition  `json:"properties"`
+	CreatedAt  string                         `json:"createdAt"`
+	UpdatedAt  string                         `json:"updatedAt"`
+}
+
+func (r EventTypeResponse) Fields() []string {
+	properties, _ := json.Marshal(r.Properties)
+	return []string{
+		r.ID,
+		r.Name,
+		r.ColorName,
+		string(properties),
+		r.CreatedAt,
+		r.UpdatedAt,
+	}
+}
+
+func (r EventTypeResponse) Headers() []string {
+	return []string{
+		"ID",
+		"Name",
+		"Color",
+		"Properties",
+		"Created At",
+		"Updated At",
+	}
+}
 
 type ExtensionsRequest struct{}
 

--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -409,7 +409,7 @@ func (r EventResponseItem) Headers() []string {
 		"Device Name",
 		"Start",
 		"End",
-		"Event Type",
+		"Event Type ID",
 		"Created At",
 		"Updated At",
 		"Metadata",

--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -373,16 +373,10 @@ type EventsRequest struct {
 	Start       string   `json:"start" form:"start,omitempty"`
 }
 
-type EventTypeSummary struct {
-	Name string `json:"name"`
-	ID   string `json:"id"`
-}
-
 type EventResponseItem struct {
 	CreatedAt   string                 `json:"createdAt"`
 	Device      DeviceSummary          `json:"device"`
 	End         string                 `json:"end"`
-	EventType   *EventTypeSummary      `json:"eventType"`
 	EventTypeID string                 `json:"eventTypeId"`
 	ID          string                 `json:"id"`
 	Metadata    map[string]string      `json:"metadata"`
@@ -394,18 +388,13 @@ type EventResponseItem struct {
 func (r EventResponseItem) Fields() []string {
 	metadata, _ := json.Marshal(r.Metadata)
 	properties, _ := json.Marshal(r.Properties)
-	eventType := ""
-	if r.EventType != nil && r.EventType.ID != "" {
-		eventType = r.EventType.Name + " (" + r.EventType.ID + ")"
-	}
-
 	return []string{
 		r.ID,
 		r.Device.ID,
 		r.Device.Name,
 		r.Start,
 		r.End,
-		eventType,
+		r.EventTypeID,
 		r.CreatedAt,
 		r.UpdatedAt,
 		string(metadata),

--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -395,11 +395,10 @@ func (r EventResponseItem) Fields() []string {
 	metadata, _ := json.Marshal(r.Metadata)
 	properties, _ := json.Marshal(r.Properties)
 	eventType := ""
-	if r.EventType != nil {
+	if r.EventType != nil && r.EventType.ID != "" {
+		eventType = r.EventType.Name + " (" + r.EventType.ID + ")"
+	} else if r.EventType != nil {
 		eventType = r.EventType.Name
-		if r.EventType.ID != "" {
-			eventType = r.EventType.Name + " (" + r.EventType.ID + ")"
-		}
 	} else if r.EventTypeID != "" {
 		eventType = r.EventTypeID
 	}

--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -606,7 +606,7 @@ type CreateEventRequest struct {
 	DeviceID    string                 `json:"deviceId"`
 	Start       string                 `json:"start"`
 	End         string                 `json:"end"`
-	Metadata    map[string]string      `json:"metadata,omitempty"`
+	Metadata    map[string]string      `json:"metadata"`
 	Properties  map[string]interface{} `json:"properties,omitempty"`
 	EventTypeID string                 `json:"eventTypeId,omitempty"`
 }

--- a/foxglove/api/client.go
+++ b/foxglove/api/client.go
@@ -448,7 +448,7 @@ func (c *FoxgloveClient) Events(req *EventsRequest) (resp []EventResponseItem, e
 	return resp, err
 }
 
-func (c *FoxgloveClient) EventTypes(req EventTypesRequest) (resp []EventTypeResponse, err error) {
+func (c *FoxgloveClient) EventTypes(req *EventTypesRequest) (resp []EventTypeResponse, err error) {
 	err = c.get("/v1/event-types", req, &resp)
 	return resp, err
 }

--- a/foxglove/api/client.go
+++ b/foxglove/api/client.go
@@ -448,6 +448,11 @@ func (c *FoxgloveClient) Events(req *EventsRequest) (resp []EventResponseItem, e
 	return resp, err
 }
 
+func (c *FoxgloveClient) EventTypes(req EventTypesRequest) (resp []EventTypeResponse, err error) {
+	err = c.get("/v1/event-types", req, &resp)
+	return resp, err
+}
+
 func (c *FoxgloveClient) Imports(req *ImportsRequest) (resp []ImportsResponse, err error) {
 	err = c.get("/v1/data/imports", req, &resp)
 	return resp, err

--- a/foxglove/cmd/event_types.go
+++ b/foxglove/cmd/event_types.go
@@ -22,7 +22,7 @@ func newListEventTypesCommand(params *baseParams) *cobra.Command {
 			format = ResolveFormat(format, isJsonFormat)
 			err := renderList(
 				os.Stdout,
-				api.EventTypesRequest{},
+				&api.EventTypesRequest{},
 				client.EventTypes,
 				format,
 			)

--- a/foxglove/cmd/event_types.go
+++ b/foxglove/cmd/event_types.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/foxglove/foxglove-cli/foxglove/api"
+	"github.com/spf13/cobra"
+)
+
+func newListEventTypesCommand(params *baseParams) *cobra.Command {
+	var format string
+	var isJsonFormat bool
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List event types",
+		Run: func(cmd *cobra.Command, args []string) {
+			client := api.NewRemoteFoxgloveClient(
+				params.baseURL, *params.clientID,
+				params.token,
+				params.userAgent,
+			)
+			format = ResolveFormat(format, isJsonFormat)
+			err := renderList(
+				os.Stdout,
+				api.EventTypesRequest{},
+				client.EventTypes,
+				format,
+			)
+			if err != nil {
+				dief("Failed to list event types: %s", err)
+			}
+		},
+	}
+	AddFormatFlag(cmd, &format)
+	AddJsonFlag(cmd, &isJsonFormat)
+	return cmd
+}

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -49,20 +49,14 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 				}
 			}
 
-			req := api.CreateEventRequest{
+			response, err := client.CreateEvent(api.CreateEventRequest{
 				DeviceID:    deviceID,
 				Start:       start,
 				End:         end,
+				Metadata:    metadata,
+				Properties:  properties,
 				EventTypeID: eventTypeID,
-			}
-			if len(metadata) > 0 {
-				req.Metadata = metadata
-			}
-			if properties != nil {
-				req.Properties = properties
-			}
-
-			response, err := client.CreateEvent(req)
+			})
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to add event: %s\n", err)
 				os.Exit(1)

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -91,6 +91,11 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 		Use:   "list",
 		Short: "List events",
 		Run: func(cmd *cobra.Command, args []string) {
+			for _, qf := range queryFields {
+				if qf != "metadata" && qf != "properties" {
+					dief("Invalid --query-field value %q: must be \"metadata\" or \"properties\"", qf)
+				}
+			}
 			client := api.NewRemoteFoxgloveClient(
 				params.baseURL, *params.clientID,
 				params.token,

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -14,7 +14,6 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 	var start string
 	var end string
 	var keyvals []string
-	var propertyKVs []string
 	var eventTypeID string
 	addEventCmd := &cobra.Command{
 		Use:   "add",
@@ -36,25 +35,11 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 				metadata[key] = val
 			}
 
-			var properties map[string]interface{}
-			if len(propertyKVs) > 0 {
-				properties = make(map[string]interface{})
-				for _, kv := range propertyKVs {
-					key, val, err := util.SplitPair(kv, ':')
-					if err != nil {
-						fmt.Fprintf(os.Stderr, "Invalid property key/value pair: %s\n", kv)
-						os.Exit(1)
-					}
-					properties[key] = util.ParsePropertyValue(val)
-				}
-			}
-
 			response, err := client.CreateEvent(api.CreateEventRequest{
 				DeviceID:    deviceID,
 				Start:       start,
 				End:         end,
 				Metadata:    metadata,
-				Properties:  properties,
 				EventTypeID: eventTypeID,
 			})
 			if err != nil {
@@ -68,7 +53,6 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 	addEventCmd.PersistentFlags().StringVarP(&start, "start", "", "", "Start of event, RFC 3339 date-time format")
 	addEventCmd.PersistentFlags().StringVarP(&end, "end", "", "", "End of event (inclusive), RFC 3339 date-time format")
 	addEventCmd.PersistentFlags().StringArrayVarP(&keyvals, "metadata", "m", []string{}, "Metadata colon-separated key value pair. Multiple may be specified.")
-	addEventCmd.PersistentFlags().StringArrayVarP(&propertyKVs, "properties", "p", []string{}, "Custom property colon-separated key:value pair. Multiple may be specified. Values are auto-parsed as number/boolean where applicable.")
 	addEventCmd.PersistentFlags().StringVarP(&eventTypeID, "event-type", "", "", "Event type ID to associate with this event (e.g. evtt_123)")
 	return addEventCmd
 }

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -14,6 +14,8 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 	var start string
 	var end string
 	var keyvals []string
+	var propertyKVs []string
+	var eventTypeID string
 	addEventCmd := &cobra.Command{
 		Use:   "add",
 		Short: "Add an event",
@@ -28,17 +30,39 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 			for _, kv := range keyvals {
 				key, val, err := util.SplitPair(kv, ':')
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "Invalid key/value pair: %s\n", kv)
+					fmt.Fprintf(os.Stderr, "Invalid metadata key/value pair: %s\n", kv)
 					os.Exit(1)
 				}
 				metadata[key] = val
 			}
-			response, err := client.CreateEvent(api.CreateEventRequest{
-				DeviceID: deviceID,
-				Start:    start,
-				End:      end,
-				Metadata: metadata,
-			})
+
+			var properties map[string]interface{}
+			if len(propertyKVs) > 0 {
+				properties = make(map[string]interface{})
+				for _, kv := range propertyKVs {
+					key, val, err := util.SplitPair(kv, ':')
+					if err != nil {
+						fmt.Fprintf(os.Stderr, "Invalid property key/value pair: %s\n", kv)
+						os.Exit(1)
+					}
+					properties[key] = util.ParsePropertyValue(val)
+				}
+			}
+
+			req := api.CreateEventRequest{
+				DeviceID:    deviceID,
+				Start:       start,
+				End:         end,
+				EventTypeID: eventTypeID,
+			}
+			if len(metadata) > 0 {
+				req.Metadata = metadata
+			}
+			if properties != nil {
+				req.Properties = properties
+			}
+
+			response, err := client.CreateEvent(req)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to add event: %s\n", err)
 				os.Exit(1)
@@ -50,6 +74,8 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 	addEventCmd.PersistentFlags().StringVarP(&start, "start", "", "", "Start of event, RFC 3339 date-time format")
 	addEventCmd.PersistentFlags().StringVarP(&end, "end", "", "", "End of event (inclusive), RFC 3339 date-time format")
 	addEventCmd.PersistentFlags().StringArrayVarP(&keyvals, "metadata", "m", []string{}, "Metadata colon-separated key value pair. Multiple may be specified.")
+	addEventCmd.PersistentFlags().StringArrayVarP(&propertyKVs, "properties", "p", []string{}, "Custom property colon-separated key:value pair. Multiple may be specified. Values are auto-parsed as number/boolean where applicable.")
+	addEventCmd.PersistentFlags().StringVarP(&eventTypeID, "event-type", "", "", "Event type ID to associate with this event (e.g. evtt_123)")
 	return addEventCmd
 }
 
@@ -64,6 +90,7 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 	var start string
 	var end string
 	var query string
+	var eventTypeID string
 	var isJsonFormat bool
 	eventsListCmd := &cobra.Command{
 		Use:   "list",
@@ -78,15 +105,16 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 			err := renderList(
 				os.Stdout,
 				&api.EventsRequest{
-					DeviceID:   deviceID,
-					DeviceName: deviceName,
-					SortBy:     sortBy,
-					SortOrder:  sortOrder,
-					Limit:      limit,
-					Offset:     offset,
-					Start:      start,
-					End:        end,
-					Query:      query,
+					DeviceID:    deviceID,
+					DeviceName:  deviceName,
+					SortBy:      sortBy,
+					SortOrder:   sortOrder,
+					Limit:       limit,
+					Offset:      offset,
+					Start:       start,
+					End:         end,
+					Query:       query,
+					EventTypeID: eventTypeID,
 				},
 				client.Events,
 				format,
@@ -103,7 +131,10 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 	eventsListCmd.PersistentFlags().StringVarP(&sortOrder, "sort-order", "", "asc", "sort order")
 	eventsListCmd.PersistentFlags().IntVarP(&limit, "limit", "", 100, "limit")
 	eventsListCmd.PersistentFlags().IntVarP(&offset, "offset", "", 0, "offset")
-	eventsListCmd.PersistentFlags().StringVarP(&query, "query", "", "", "Filter by metadata with keyword or \"$key:$value\"")
+	eventsListCmd.PersistentFlags().StringVarP(&start, "start", "", "", "Exclude events before this time, RFC 3339 or ISO 8601 format")
+	eventsListCmd.PersistentFlags().StringVarP(&end, "end", "", "", "Exclude events after this time, RFC 3339 or ISO 8601 format")
+	eventsListCmd.PersistentFlags().StringVarP(&query, "query", "", "", "Filter by properties or metadata, e.g. \"$key:$value\". See API docs for query syntax.")
+	eventsListCmd.PersistentFlags().StringVarP(&eventTypeID, "event-type", "", "", "Filter by event type ID (e.g. evtt_123)")
 	AddDeviceAutocompletion(eventsListCmd, params)
 	AddFormatFlag(eventsListCmd, &format)
 	AddJsonFlag(eventsListCmd, &isJsonFormat)

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -85,6 +85,7 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 	var end string
 	var query string
 	var eventTypeID string
+	var queryFields []string
 	var isJsonFormat bool
 	eventsListCmd := &cobra.Command{
 		Use:   "list",
@@ -109,6 +110,7 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 					End:         end,
 					Query:       query,
 					EventTypeID: eventTypeID,
+					QueryFields: queryFields,
 				},
 				client.Events,
 				format,
@@ -129,6 +131,7 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 	eventsListCmd.PersistentFlags().StringVarP(&end, "end", "", "", "Exclude events after this time, RFC 3339 or ISO 8601 format")
 	eventsListCmd.PersistentFlags().StringVarP(&query, "query", "", "", "Filter by properties or metadata, e.g. \"$key:$value\". See API docs for query syntax.")
 	eventsListCmd.PersistentFlags().StringVarP(&eventTypeID, "event-type", "", "", "Filter by event type ID (e.g. evtt_123)")
+	eventsListCmd.PersistentFlags().StringArrayVarP(&queryFields, "query-field", "", []string{}, "Fields to query by (\"metadata\" or \"properties\"). Multiple may be specified. Defaults to \"metadata\".")
 	AddDeviceAutocompletion(eventsListCmd, params)
 	AddFormatFlag(eventsListCmd, &format)
 	AddJsonFlag(eventsListCmd, &isJsonFormat)

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -53,7 +53,7 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 	addEventCmd.PersistentFlags().StringVarP(&start, "start", "", "", "Start of event, RFC 3339 date-time format")
 	addEventCmd.PersistentFlags().StringVarP(&end, "end", "", "", "End of event (inclusive), RFC 3339 date-time format")
 	addEventCmd.PersistentFlags().StringArrayVarP(&keyvals, "metadata", "m", []string{}, "Metadata colon-separated key value pair. Multiple may be specified.")
-	addEventCmd.PersistentFlags().StringVarP(&eventTypeID, "event-type", "", "", "Event type ID to associate with this event (e.g. evtt_123)")
+	addEventCmd.PersistentFlags().StringVarP(&eventTypeID, "event-type-id", "", "", "Event type ID to associate with this event (e.g. evtt_123)")
 	return addEventCmd
 }
 
@@ -119,7 +119,7 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 	eventsListCmd.PersistentFlags().StringVarP(&start, "start", "", "", "Exclude events before this time, RFC 3339 or ISO 8601 format")
 	eventsListCmd.PersistentFlags().StringVarP(&end, "end", "", "", "Exclude events after this time, RFC 3339 or ISO 8601 format")
 	eventsListCmd.PersistentFlags().StringVarP(&query, "query", "", "", "Filter by properties or metadata, e.g. \"$key:$value\". See API docs for query syntax.")
-	eventsListCmd.PersistentFlags().StringVarP(&eventTypeID, "event-type", "", "", "Filter by event type ID (e.g. evtt_123)")
+	eventsListCmd.PersistentFlags().StringVarP(&eventTypeID, "event-type-id", "", "", "Filter by event type ID (e.g. evtt_123)")
 	eventsListCmd.PersistentFlags().StringArrayVarP(&queryFields, "query-field", "", []string{}, "Fields to query by (\"metadata\" or \"properties\"). Multiple may be specified. Defaults to \"metadata\".")
 	AddDeviceAutocompletion(eventsListCmd, params)
 	AddFormatFlag(eventsListCmd, &format)

--- a/foxglove/cmd/root.go
+++ b/foxglove/cmd/root.go
@@ -155,6 +155,10 @@ func Execute(version string) {
 		Use:   "extensions",
 		Short: "List and publish Studio extensions",
 	}
+	eventTypesCmd := &cobra.Command{
+		Use:   "event-types",
+		Short: "List and manage event types",
+	}
 	pendingImportsCmd := &cobra.Command{
 		Use:   "pending-imports",
 		Short: "List pending imports",
@@ -240,6 +244,7 @@ func Execute(version string) {
 		newDeleteSessionCommand(params),
 	)
 	eventsCmd.AddCommand(newListEventsCommand(params), newAddEventCommand(params))
+	eventTypesCmd.AddCommand(newListEventTypesCommand(params))
 	extensionsCmd.AddCommand(newListExtensionsCommand(params))
 	extensionsCmd.AddCommand(newPublishExtensionCommand(params))
 	extensionsCmd.AddCommand(newUnpublishExtensionCommand(params))
@@ -256,6 +261,7 @@ func Execute(version string) {
 		attachmentsCmd,
 		recordingsCmd,
 		eventsCmd,
+		eventTypesCmd,
 		pendingImportsCmd,
 		projectsCmd,
 		configCmd,

--- a/foxglove/cmd/root.go
+++ b/foxglove/cmd/root.go
@@ -157,7 +157,7 @@ func Execute(version string) {
 	}
 	eventTypesCmd := &cobra.Command{
 		Use:   "event-types",
-		Short: "List and manage event types",
+		Short: "List event types",
 	}
 	pendingImportsCmd := &cobra.Command{
 		Use:   "pending-imports",

--- a/foxglove/util/split_pair.go
+++ b/foxglove/util/split_pair.go
@@ -8,8 +8,8 @@ import (
 
 // Split a key/value string on a given delimiter into a pair
 func SplitPair(kv string, delim rune) (key string, value string, err error) {
-	parts := strings.FieldsFunc(kv, func(c rune) bool { return c == delim })
-	if len(parts) != 2 {
+	parts := strings.SplitN(kv, string(delim), 2)
+	if len(parts) != 2 || parts[0] == "" {
 		return "", "", fmt.Errorf("invalid key/value pair: %s", kv)
 	}
 	return parts[0], parts[1], nil
@@ -17,7 +17,8 @@ func SplitPair(kv string, delim rune) (key string, value string, err error) {
 
 // ParsePropertyValue attempts to interpret a string as a bool, number, or falls back to string.
 func ParsePropertyValue(val string) interface{} {
-	if b, err := strconv.ParseBool(val); err == nil {
+	if strings.EqualFold(val, "true") || strings.EqualFold(val, "false") {
+		b, _ := strconv.ParseBool(val)
 		return b
 	}
 	if f, err := strconv.ParseFloat(val, 64); err == nil {

--- a/foxglove/util/split_pair.go
+++ b/foxglove/util/split_pair.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -12,4 +13,15 @@ func SplitPair(kv string, delim rune) (key string, value string, err error) {
 		return "", "", fmt.Errorf("invalid key/value pair: %s", kv)
 	}
 	return parts[0], parts[1], nil
+}
+
+// ParsePropertyValue attempts to interpret a string as a bool, number, or falls back to string.
+func ParsePropertyValue(val string) interface{} {
+	if b, err := strconv.ParseBool(val); err == nil {
+		return b
+	}
+	if f, err := strconv.ParseFloat(val, 64); err == nil {
+		return f
+	}
+	return val
 }

--- a/foxglove/util/split_pair.go
+++ b/foxglove/util/split_pair.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 )
 
@@ -13,16 +12,4 @@ func SplitPair(kv string, delim rune) (key string, value string, err error) {
 		return "", "", fmt.Errorf("invalid key/value pair: %s", kv)
 	}
 	return parts[0], parts[1], nil
-}
-
-// ParsePropertyValue attempts to interpret a string as a bool, number, or falls back to string.
-func ParsePropertyValue(val string) interface{} {
-	if strings.EqualFold(val, "true") || strings.EqualFold(val, "false") {
-		b, _ := strconv.ParseBool(val)
-		return b
-	}
-	if f, err := strconv.ParseFloat(val, 64); err == nil {
-		return f
-	}
-	return val
 }

--- a/foxglove/util/split_pair_test.go
+++ b/foxglove/util/split_pair_test.go
@@ -39,31 +39,3 @@ func TestSplitPair(t *testing.T) {
 	})
 }
 
-func TestParsePropertyValue(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected interface{}
-	}{
-		{"true", true},
-		{"false", false},
-		{"True", true},
-		{"FALSE", false},
-		{"0", float64(0)},
-		{"1", float64(1)},
-		{"42", float64(42)},
-		{"3.14", float64(3.14)},
-		{"-1", float64(-1)},
-		{"hello", "hello"},
-		{"", ""},
-		{"t", "t"},
-		{"f", "f"},
-		{"yes", "yes"},
-		{"no", "no"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			result := ParsePropertyValue(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}

--- a/foxglove/util/split_pair_test.go
+++ b/foxglove/util/split_pair_test.go
@@ -1,0 +1,69 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitPair(t *testing.T) {
+	t.Run("splits simple key:value", func(t *testing.T) {
+		k, v, err := SplitPair("foo:bar", ':')
+		assert.Nil(t, err)
+		assert.Equal(t, "foo", k)
+		assert.Equal(t, "bar", v)
+	})
+
+	t.Run("preserves colons in value", func(t *testing.T) {
+		k, v, err := SplitPair("url:https://example.com", ':')
+		assert.Nil(t, err)
+		assert.Equal(t, "url", k)
+		assert.Equal(t, "https://example.com", v)
+	})
+
+	t.Run("allows empty value", func(t *testing.T) {
+		k, v, err := SplitPair("key:", ':')
+		assert.Nil(t, err)
+		assert.Equal(t, "key", k)
+		assert.Equal(t, "", v)
+	})
+
+	t.Run("rejects missing delimiter", func(t *testing.T) {
+		_, _, err := SplitPair("nocolon", ':')
+		assert.NotNil(t, err)
+	})
+
+	t.Run("rejects empty key", func(t *testing.T) {
+		_, _, err := SplitPair(":value", ':')
+		assert.NotNil(t, err)
+	})
+}
+
+func TestParsePropertyValue(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{"true", true},
+		{"false", false},
+		{"True", true},
+		{"FALSE", false},
+		{"0", float64(0)},
+		{"1", float64(1)},
+		{"42", float64(42)},
+		{"3.14", float64(3.14)},
+		{"-1", float64(-1)},
+		{"hello", "hello"},
+		{"", ""},
+		{"t", "t"},
+		{"f", "f"},
+		{"yes", "yes"},
+		{"no", "no"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := ParsePropertyValue(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
### Changelog

Add support for:
 - listing events with filters on start, end and queryFields
 - displaying event properties
 - listing event types

### Docs

Documented by `foxglove events list --help` and similar help commands.

### Description

Adds missing support for event properties and event types that our API supports. See API docs here https://docs.foxglove.dev/api#tag/Events/paths/~1events/get

Changes to the following commands:

`foxglove events add`

 - an event type can be specified on event creation via `foxglove events add --event-type <event_type_id>`

`foxglove events list`

 - filter by properties via `foxglove events list --query <key:value> --query-field properties`
 - filter by event type via `foxglove events list --event-type-id <event_type_id>`
 - filter by start and end time via `foxglove events list --start <start_timestamp> --end <end_timestamp>`
 - list results now include event type and properties

`foxglove event-types list`

 - new command to list event types for the org

Note: this change does not include adding or updating properties on an event via the cli. Currently this requires sending the API the proper value types, which means parsing the user input in the cli. This is not a straightforward problem (how do we know the difference between 1.0 as a number and 1.0 as a string?) so it's probably better handled in a separate PR.