### PR TITLE
Add missing options to StreamRequest and update export command

### DIFF
--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -37,18 +37,28 @@ type UploadResponse struct {
 }
 
 type StreamRequest struct {
-	RecordingID  string     `json:"recordingId,omitempty"`
-	Key          string     `json:"key,omitempty"`
-	ImportID     string     `json:"importId,omitempty"`
-	ProjectID    string     `json:"projectId,omitempty"`
-	DeviceID     string     `json:"device.id,omitempty"`
-	DeviceName   string     `json:"device.name,omitempty"`
-	Start        *time.Time `json:"start,omitempty"`
-	End          *time.Time `json:"end,omitempty"`
-	OutputFormat string     `json:"outputFormat"`
-	Topics       []string   `json:"topics"`
-	SessionID    string     `json:"sessionId,omitempty"`
-	SessionKey   string     `json:"sessionKey,omitempty"`
+	RecordingID           string     `json:"recordingId,omitempty"`
+	Key                   string     `json:"key,omitempty"`
+	ImportID              string     `json:"importId,omitempty"`
+	ProjectID             string     `json:"projectId,omitempty"`
+	DeviceID              string     `json:"device.id,omitempty"`
+	DeviceName            string     `json:"device.name,omitempty"`
+	Start                 *time.Time `json:"start,omitempty"`
+	End                   *time.Time `json:"end,omitempty"`
+	OutputFormat          string     `json:"outputFormat"`
+	CompressionFormat     *string    `json:"compressionFormat,omitempty"`
+	IncludeAttachments    bool       `json:"includeAttachments,omitempty"`
+	ReplayPolicy          string     `json:"replayPolicy,omitempty"`
+	ReplayLookbackSeconds float64    `json:"replayLookbackSeconds,omitempty"`
+	Topics                []string   `json:"topics"`
+	SessionID             string     `json:"sessionId,omitempty"`
+	SessionKey            string     `json:"sessionKey,omitempty"`
+}
+
+// isMCAPOutputFormat reports whether the output format produces an MCAP file.
+// "mcap0" is a deprecated alias for "mcap".
+func isMCAPOutputFormat(format string) bool {
+	return format == "mcap" || format == "mcap0"
 }
 
 func (req *StreamRequest) Validate() error {
@@ -70,6 +80,25 @@ func (req *StreamRequest) Validate() error {
 	}
 	if req.Start != nil && req.End != nil && req.End.Before(*req.Start) {
 		return fmt.Errorf("end must be after or equal to start")
+	}
+	if req.CompressionFormat != nil {
+		switch *req.CompressionFormat {
+		case "", "zstd", "lz4":
+		default:
+			return fmt.Errorf(`invalid compression format %q: supply "", zstd, or lz4`, *req.CompressionFormat)
+		}
+		if !isMCAPOutputFormat(req.OutputFormat) {
+			return fmt.Errorf("compression format is only valid for mcap output")
+		}
+	}
+	if req.IncludeAttachments && !isMCAPOutputFormat(req.OutputFormat) {
+		return fmt.Errorf("include-attachments is only valid for mcap output")
+	}
+	if req.ReplayPolicy != "" && req.ReplayPolicy != "lastPerChannel" {
+		return fmt.Errorf(`invalid replay policy %q: supply "" or lastPerChannel`, req.ReplayPolicy)
+	}
+	if req.ReplayLookbackSeconds < 0 {
+		return fmt.Errorf("replay-lookback-seconds must be >= 0")
 	}
 	return nil
 }

--- a/foxglove/cmd/export.go
+++ b/foxglove/cmd/export.go
@@ -831,6 +831,10 @@ func createStreamRequest(
 	sessionID string,
 	sessionKey string,
 	projectID string,
+	compressionFormat *string,
+	includeAttachments bool,
+	replayPolicy string,
+	replayLookbackSeconds float64,
 ) (*api.StreamRequest, error) {
 	var startTime, endTime *time.Time
 	if start != "" {
@@ -852,18 +856,22 @@ func createStreamRequest(
 	topics := strings.FieldsFunc(topicList, func(c rune) bool { return c == ',' })
 
 	request := &api.StreamRequest{
-		RecordingID:  recordingID,
-		Key:          key,
-		ImportID:     importID,
-		DeviceName:   deviceName,
-		DeviceID:     deviceID,
-		Start:        startTime,
-		End:          endTime,
-		OutputFormat: outputFormat,
-		Topics:       topics,
-		SessionID:    sessionID,
-		SessionKey:   sessionKey,
-		ProjectID:    projectID,
+		RecordingID:           recordingID,
+		Key:                   key,
+		ImportID:              importID,
+		DeviceName:            deviceName,
+		DeviceID:              deviceID,
+		Start:                 startTime,
+		End:                   endTime,
+		OutputFormat:          outputFormat,
+		CompressionFormat:     compressionFormat,
+		IncludeAttachments:    includeAttachments,
+		ReplayPolicy:          replayPolicy,
+		ReplayLookbackSeconds: replayLookbackSeconds,
+		Topics:                topics,
+		SessionID:             sessionID,
+		SessionKey:            sessionKey,
+		ProjectID:             projectID,
 	}
 	if err := request.Validate(); err != nil {
 		return nil, err
@@ -887,6 +895,10 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 	var sessionID string
 	var sessionKey string
 	var projectID string
+	var compression string
+	var includeAttachments bool
+	var replayPolicy string
+	var replayLookbackSeconds float64
 	exportCmd := &cobra.Command{
 		Use:   "export",
 		Short: "Export a data selection from Foxglove Data Platform",
@@ -903,6 +915,13 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 			if isJsonOutput {
 				outputFormat = "json"
 			}
+			// Only send compressionFormat if the user explicitly set it, so the
+			// API default (lz4) is used otherwise. An explicit empty value means
+			// no compression.
+			var compressionFormat *string
+			if cmd.Flags().Changed("compression") {
+				compressionFormat = &compression
+			}
 			request, err := createStreamRequest(
 				recordingID,
 				key,
@@ -916,6 +935,10 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 				sessionID,
 				sessionKey,
 				projectID,
+				compressionFormat,
+				includeAttachments,
+				replayPolicy,
+				replayLookbackSeconds,
 			)
 			if err != nil {
 				dief("Failed to build request: %s", err)
@@ -976,6 +999,10 @@ func newExportCommand(params *baseParams) (*cobra.Command, error) {
 	exportCmd.PersistentFlags().StringVarP(&sessionID, "session-id", "", "", "session ID")
 	exportCmd.PersistentFlags().StringVarP(&sessionKey, "session-key", "", "", "Session key")
 	exportCmd.PersistentFlags().StringVarP(&projectID, "project-id", "", "", "Project ID (required when using --session-key)")
+	exportCmd.PersistentFlags().StringVarP(&compression, "compression", "", "lz4", `mcap chunk compression format: "" (none), zstd, or lz4 (mcap output only)`)
+	exportCmd.PersistentFlags().BoolVar(&includeAttachments, "include-attachments", false, "include attachments in streamed data (mcap output only)")
+	exportCmd.PersistentFlags().StringVarP(&replayPolicy, "replay-policy", "", "", `replay policy: "" (none) or lastPerChannel`)
+	exportCmd.PersistentFlags().Float64VarP(&replayLookbackSeconds, "replay-lookback-seconds", "", 0, "max seconds to look back before start for lastPerChannel replay policy")
 	AddDeviceAutocompletion(exportCmd, params)
 	return exportCmd, nil
 }


### PR DESCRIPTION
### Changelog

Added new flags to the export command: `--compression`, `--include-attachments`, `--replay-policy`, and `--replay-lookback-seconds`. See [api docs](https://docs.foxglove.dev/api#tag/Stream-data/paths/~1data~1stream/post) for more info.

### Docs

<!-- Link to a PR or Linear ticket tracking documentation. Write "None" if no documentation changes are needed. -->

### Description

This pull request adds support for new streaming options to the export command and API, improving flexibility and control over data export. The main changes introduce new fields to the `StreamRequest` struct and expose corresponding command-line flags, with validation to ensure these options are used correctly.

**API and CLI enhancements for streaming options:**

* Added new fields to `StreamRequest` (`compressionFormat`, `includeAttachments`, `replayPolicy`, `replayLookbackSeconds`) to support advanced export options.
* Implemented validation logic in `StreamRequest.Validate()` to ensure that new options are only used with compatible output formats and have valid values.

**Command-line interface improvements:**

* Added new flags to the export command: `--compression`, `--include-attachments`, `--replay-policy`, and `--replay-lookback-seconds`, allowing users to specify these options from the CLI. [[1]](diffhunk://#diff-97773ff697450f0d1187febb1ac098bc3e41fbb80ef08d196d7209d1b00257b1R898-R901) [[2]](diffhunk://#diff-97773ff697450f0d1187febb1ac098bc3e41fbb80ef08d196d7209d1b00257b1R1002-R1005)
* Updated the export command to only send `compressionFormat` if the flag is explicitly set, preserving API defaults otherwise.
* Passed the new options from the CLI through to the API request by updating `createStreamRequest` and related function calls. [[1]](diffhunk://#diff-97773ff697450f0d1187febb1ac098bc3e41fbb80ef08d196d7209d1b00257b1R834-R837) [[2]](diffhunk://#diff-97773ff697450f0d1187febb1ac098bc3e41fbb80ef08d196d7209d1b00257b1R867-R870) [[3]](diffhunk://#diff-97773ff697450f0d1187febb1ac098bc3e41fbb80ef08d196d7209d1b00257b1R938-R941)


<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

