### PR TITLE
Add Claude PR review GitHub Action

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,16 @@
+name: PR Review
+
+on:
+  pull_request: {}
+
+jobs:
+  review:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+      id-token: write
+    uses: foxglove/actions/.github/workflows/review.yml@main
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
Adds the shared Claude PR review workflow used across other Foxglove repos (see [foxglove-python](https://github.com/foxglove/foxglove-python/blob/main/.github/workflows/pr-review.yml) for example).

The workflow calls `foxglove/actions/.github/workflows/review.yml@main` on pull requests from this repository, excluding forks.