### PR TITLE
add topics command

### DIFF
--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -107,6 +107,40 @@ type StreamResponse struct {
 	Link string `json:"link"`
 }
 
+type TopicsRequest struct {
+	Start          string `form:"start,omitempty"`
+	End            string `form:"end,omitempty"`
+	RecordingID    string `form:"recordingId,omitempty"`
+	RecordingKey   string `form:"recordingKey,omitempty"`
+	DeviceID       string `form:"deviceId,omitempty"`
+	DeviceName     string `form:"deviceName,omitempty"`
+	SessionID      string `form:"sessionId,omitempty"`
+	SessionKey     string `form:"sessionKey,omitempty"`
+	IncludeSchemas bool   `form:"includeSchemas,omitempty"`
+	SortBy         string `form:"sortBy,omitempty"`
+	SortOrder      string `form:"sortOrder,omitempty"`
+	ProjectID      string `form:"projectId,omitempty"`
+	Limit          int    `form:"limit,omitempty"`
+	Offset         int    `form:"offset,omitempty"`
+}
+
+type TopicsResponse struct {
+	Encoding       string `json:"encoding"`
+	Schema         string `json:"schema,omitempty"`
+	SchemaEncoding string `json:"schemaEncoding"`
+	SchemaName     string `json:"schemaName"`
+	Topic          string `json:"topic"`
+	Version        string `json:"version"`
+}
+
+func (r TopicsResponse) Headers() []string {
+	return []string{"Topic", "Schema Name", "Schema Encoding", "Encoding", "Version", "Schema"}
+}
+
+func (r TopicsResponse) Fields() []string {
+	return []string{r.Topic, r.SchemaName, r.SchemaEncoding, r.Encoding, r.Version, r.Schema}
+}
+
 type DeviceCodeRequest struct {
 	ClientID string `json:"clientId"`
 }

--- a/foxglove/api/client.go
+++ b/foxglove/api/client.go
@@ -482,6 +482,11 @@ func (c *FoxgloveClient) Coverage(req *CoverageRequest) (resp []CoverageResponse
 	return resp, err
 }
 
+func (c *FoxgloveClient) Topics(req *TopicsRequest) (resp []TopicsResponse, err error) {
+	err = c.get("/v1/data/topics", *req, &resp)
+	return resp, err
+}
+
 func (c *FoxgloveClient) Extensions(req ExtensionsRequest) (resp []ExtensionResponse, err error) {
 	err = c.get("/v1/extensions", req, &resp)
 	return resp, err

--- a/foxglove/api/mock_service.go
+++ b/foxglove/api/mock_service.go
@@ -95,6 +95,16 @@ func (s *MockFoxgloveServer) stream(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (s *MockFoxgloveServer) topics(w http.ResponseWriter, r *http.Request) {
+	_ = json.NewEncoder(w).Encode([]TopicsResponse{{
+		Encoding:       "cdr",
+		SchemaEncoding: "ros2msg",
+		SchemaName:     "sensor_msgs/msg/Image",
+		Topic:          "/camera/image",
+		Version:        "1",
+	}})
+}
+
 func (s *MockFoxgloveServer) lookupDevice(id, name string) *DevicesResponse {
 	for _, device := range s.registeredDevices {
 		if device.ID == id || device.Name == name {
@@ -559,6 +569,7 @@ func makeRoutes(sv *MockFoxgloveServer) *mux.Router {
 	r.HandleFunc("/v1/signin", sv.signIn).Methods("POST")
 	r.HandleFunc("/v1/custom-properties", sv.withAuthz(sv.customProperties)).Methods("GET")
 	r.HandleFunc("/v1/data/stream", sv.withAuthz(sv.stream)).Methods("POST")
+	r.HandleFunc("/v1/data/topics", sv.withAuthz(sv.topics)).Methods("GET")
 	r.HandleFunc("/v1/data/imports", sv.withAuthz(sv.imports)).Methods("GET")
 	r.HandleFunc("/v1/data/upload", sv.withAuthz(sv.uploadRedirect)).Methods("POST")
 	r.HandleFunc("/v1/auth/device-code", sv.deviceCode).Methods("POST")

--- a/foxglove/cmd/root.go
+++ b/foxglove/cmd/root.go
@@ -167,6 +167,10 @@ func Execute(version string) {
 		Use:   "projects",
 		Short: "List and manage projects",
 	}
+	topicsCmd := &cobra.Command{
+		Use:   "topics",
+		Short: "List topics",
+	}
 	sessionsCmd := &cobra.Command{
 		Use:   "sessions",
 		Short: "List and manage sessions",
@@ -250,6 +254,7 @@ func Execute(version string) {
 	extensionsCmd.AddCommand(newUnpublishExtensionCommand(params))
 	pendingImportsCmd.AddCommand(newPendingImportsCommand(params))
 	projectsCmd.AddCommand(newListProjectsCommand(params))
+	topicsCmd.AddCommand(newListTopicsCommand(params))
 
 	rootCmd.AddCommand(
 		authCmd,
@@ -264,6 +269,7 @@ func Execute(version string) {
 		eventTypesCmd,
 		pendingImportsCmd,
 		projectsCmd,
+		topicsCmd,
 		configCmd,
 	)
 

--- a/foxglove/cmd/topics.go
+++ b/foxglove/cmd/topics.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/foxglove/foxglove-cli/foxglove/api"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func newListTopicsCommand(params *baseParams) *cobra.Command {
+	var request api.TopicsRequest
+	var format string
+	var isJSONFormat bool
+	topicCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List topics",
+		Long: `List topics.
+
+One of --device-id, --device-name, --recording-id, --recording-key, --session-id, or --session-key is required.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := validateTopicsRequest(request); err != nil {
+				dief("%s", err)
+			}
+			if err := validateSessionKeyRequiresProjectID(request.SessionKey, request.ProjectID); err != nil {
+				dief("%s", err)
+			}
+			start, err := maybeConvertToRFC3339(request.Start)
+			if err != nil {
+				dief("failed to parse start time: %s", err)
+			}
+			end, err := maybeConvertToRFC3339(request.End)
+			if err != nil {
+				dief("failed to parse end time: %s", err)
+			}
+			request.Start = start
+			request.End = end
+			format = ResolveFormat(format, isJSONFormat)
+
+			client := api.NewRemoteFoxgloveClient(
+				params.baseURL,
+				*params.clientID,
+				params.token,
+				params.userAgent,
+			)
+			if err := renderList(os.Stdout, &request, client.Topics, format); err != nil {
+				dief("Failed to list topics: %s", err)
+			}
+		},
+	}
+
+	topicCmd.PersistentFlags().StringVar(&request.ProjectID, "project-id", viper.GetString("default_project_id"), "Project ID (required when using --session-key)")
+	topicCmd.PersistentFlags().StringVar(&request.DeviceID, "device-id", "", "Device ID")
+	topicCmd.PersistentFlags().StringVar(&request.DeviceName, "device-name", "", "Device name")
+	topicCmd.PersistentFlags().StringVar(&request.RecordingID, "recording-id", "", "Recording ID")
+	topicCmd.PersistentFlags().StringVar(&request.RecordingKey, "recording-key", "", "Recording key")
+	topicCmd.PersistentFlags().StringVar(&request.SessionID, "session-id", "", "Session ID")
+	topicCmd.PersistentFlags().StringVar(&request.SessionKey, "session-key", "", "Session key")
+	topicCmd.PersistentFlags().StringVar(&request.Start, "start", "", "Start of topic time range (ISO8601)")
+	topicCmd.PersistentFlags().StringVar(&request.End, "end", "", "End of topic time range (ISO8601)")
+	topicCmd.PersistentFlags().BoolVar(&request.IncludeSchemas, "include-schemas", false, "Include full topic schemas")
+	topicCmd.PersistentFlags().StringVar(&request.SortBy, "sort-by", "", "Sort by topic or version")
+	topicCmd.PersistentFlags().StringVar(&request.SortOrder, "sort-order", "", "Sort order (asc or desc)")
+	topicCmd.PersistentFlags().IntVar(&request.Limit, "limit", 0, "Maximum number of topics to return")
+	topicCmd.PersistentFlags().IntVar(&request.Offset, "offset", 0, "Number of topics to skip")
+	AddFormatFlag(topicCmd, &format)
+	AddJsonFlag(topicCmd, &isJSONFormat)
+	return topicCmd
+}
+
+func validateTopicsRequest(request api.TopicsRequest) error {
+	if request.DeviceID == "" && request.DeviceName == "" && request.RecordingID == "" &&
+		request.RecordingKey == "" && request.SessionID == "" && request.SessionKey == "" {
+		return fmt.Errorf("provide one of --device-id, --device-name, --recording-id, --recording-key, --session-id, or --session-key")
+	}
+	return nil
+}

--- a/foxglove/cmd/topics.go
+++ b/foxglove/cmd/topics.go
@@ -65,6 +65,7 @@ One of --device-id, --device-name, --recording-id, --recording-key, --session-id
 	topicCmd.PersistentFlags().IntVar(&request.Limit, "limit", 0, "Maximum number of topics to return")
 	topicCmd.PersistentFlags().IntVar(&request.Offset, "offset", 0, "Number of topics to skip")
 	AddFormatFlag(topicCmd, &format)
+	AddDeviceAutocompletion(topicCmd, params)
 	AddJsonFlag(topicCmd, &isJSONFormat)
 	return topicCmd
 }

--- a/foxglove/cmd/topics_test.go
+++ b/foxglove/cmd/topics_test.go
@@ -35,7 +35,7 @@ func TestTopicsRequest(t *testing.T) {
 		assert.Equal(t, "Bearer token", r.Header.Get("Authorization"))
 		assert.Equal(t, "device-123", r.URL.Query().Get("deviceId"))
 		assert.Equal(t, "2024-01-01T00:00:00Z", r.URL.Query().Get("start"))
-		assert.Empty(t, r.URL.Query().Get("importId"))
+		assert.Empty(t, r.URL.Query().Get("end"))
 		assert.Equal(t, "true", r.URL.Query().Get("includeSchemas"))
 		assert.Equal(t, "topic", r.URL.Query().Get("sortBy"))
 		assert.Equal(t, "10", r.URL.Query().Get("limit"))

--- a/foxglove/cmd/topics_test.go
+++ b/foxglove/cmd/topics_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/foxglove/foxglove-cli/foxglove/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTopicsCommand(t *testing.T) {
+	ctx := context.Background()
+	sv, err := api.NewMockServer(ctx)
+	assert.NoError(t, err)
+
+	t.Run("lists topics", func(t *testing.T) {
+		client := api.NewMockAuthedClient(t, sv.BaseURL())
+		topics, err := client.Topics(&api.TopicsRequest{})
+		assert.NoError(t, err)
+		assert.Contains(t, topics, api.TopicsResponse{
+			Encoding:       "cdr",
+			SchemaEncoding: "ros2msg",
+			SchemaName:     "sensor_msgs/msg/Image",
+			Topic:          "/camera/image",
+			Version:        "1",
+		})
+	})
+}
+
+func TestTopicsRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/data/topics", r.URL.Path)
+		assert.Equal(t, "Bearer token", r.Header.Get("Authorization"))
+		assert.Equal(t, "device-123", r.URL.Query().Get("deviceId"))
+		assert.Equal(t, "2024-01-01T00:00:00Z", r.URL.Query().Get("start"))
+		assert.Empty(t, r.URL.Query().Get("importId"))
+		assert.Equal(t, "true", r.URL.Query().Get("includeSchemas"))
+		assert.Equal(t, "topic", r.URL.Query().Get("sortBy"))
+		assert.Equal(t, "10", r.URL.Query().Get("limit"))
+		_, _ = w.Write([]byte(`[{"encoding":"cdr","schema":"c2NoZW1h","schemaEncoding":"ros2msg","schemaName":"pkg/msg/Foo","topic":"/foo","version":"1"}]`))
+	}))
+	defer server.Close()
+
+	client := api.NewRemoteFoxgloveClient(server.URL, "client", "token", "user-agent")
+	topics, err := client.Topics(&api.TopicsRequest{
+		DeviceID:       "device-123",
+		Start:          "2024-01-01T00:00:00Z",
+		IncludeSchemas: true,
+		SortBy:         "topic",
+		Limit:          10,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []api.TopicsResponse{{
+		Encoding:       "cdr",
+		Schema:         "c2NoZW1h",
+		SchemaEncoding: "ros2msg",
+		SchemaName:     "pkg/msg/Foo",
+		Topic:          "/foo",
+		Version:        "1",
+	}}, topics)
+}
+
+func TestListTopicsCommandUsesBaseParams(t *testing.T) {
+	clientID := "custom-client"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer custom-token", r.Header.Get("Authorization"))
+		assert.Equal(t, "foxglove-cli/test-version", r.Header.Get("User-Agent"))
+		assert.Equal(t, "rec_123", r.URL.Query().Get("recordingId"))
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	cmd := newListTopicsCommand(&baseParams{
+		baseURL:   server.URL,
+		clientID:  &clientID,
+		token:     "custom-token",
+		userAgent: "foxglove-cli/test-version",
+	})
+	cmd.SetArgs([]string{"--recording-id", "rec_123", "--format", "json"})
+
+	assert.NoError(t, cmd.Execute())
+}
+
+func TestValidateTopicsRequest(t *testing.T) {
+	assert.EqualError(t, validateTopicsRequest(api.TopicsRequest{}),
+		"provide one of --device-id, --device-name, --recording-id, --recording-key, --session-id, or --session-key")
+	assert.NoError(t, validateTopicsRequest(api.TopicsRequest{RecordingID: "rec_123"}))
+}


### PR DESCRIPTION
### Changelog

Adds support for `topics list`, see the [topics API docs](https://docs.foxglove.dev/api#tag/Topics/paths/~1data~1topics/get) for more info.

### Docs

See [API docs](https://docs.foxglove.dev/api#tag/Topics/paths/~1data~1topics/get).

### Description

Adds a new topics command group. Today the only command is `list`, mirroring what is supported via the API. All non-deprecated topic parameters are accepted.

Example usage
```
> foxglove topics list --device-name <your-device>

|     Topic     |  Schema Name  |  Schema Encoding  |  Encoding  |              Version              |  Schema  |
|---------------|---------------|-------------------|------------|-----------------------------------|----------|
| /diagnostics  | raw_bytes     |                   | raw        | d41d8cd98f00b204e9800998ecf8427e  |          |
| /system/cpu   | raw_bytes     |                   | raw        | d41d8cd98f00b204e9800998ecf8427e  |          |
| /system/mem   | raw_bytes     |                   | raw        | d41d8cd98f00b204e9800998ecf8427e  |          |
```