### PR TITLE
Add events and event-types commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,14 +175,31 @@ $ foxglove events add --device-id dev_mHH1Cp4gPybCPR8y \
     --metadata requires-labeling:true
 ```
 
-List all events:
+List, get, edit, and delete events:
 
 ```
-$ foxglove events list
-|          ID          |      DEVICE ID       |            START            |             END             |        CREATED AT        |        UPDATED AT        |           METADATA           |
-|----------------------|----------------------|-----------------------------|-----------------------------|--------------------------|--------------------------|------------------------------|
-| evt_N6doUtPYh8i7iZxf | dev_jCuXYeFwCkZowpHs | 2023-04-19T13:22:44.194041Z | 2023-04-19T13:22:44.194041Z | 2023-04-19T13:22:44.263Z | 2023-04-19T13:22:44.263Z | {}                           |
-| evt_idMGJImlICYP4dcy | dev_mHH1Cp4gPybCPR8y | 2023-04-19T13:26:37.030302Z | 2023-04-19T13:26:37.030302Z | 2023-04-19T13:26:37.080Z | 2023-04-19T13:26:37.080Z | {"requires-labeling":"true"} |
+$ foxglove events list --device-id dev_mHH1Cp4gPybCPR8y --event-type-id evtt_123
+$ foxglove events get evt_idMGJImlICYP4dcy
+$ foxglove events edit evt_idMGJImlICYP4dcy --metadata note:updated
+$ foxglove events delete evt_idMGJImlICYP4dcy
+```
+
+### Event types
+
+Create event types with a color and an ordered list of custom properties:
+
+```
+$ foxglove event-types add --name "Hardware Fault" --color-name red \
+    --custom-property cprop_abc:true
+```
+
+List, get, edit, and delete event types:
+
+```
+$ foxglove event-types list
+$ foxglove event-types get evtt_123
+$ foxglove event-types edit evtt_123 --name Fault --color-name orange
+$ foxglove event-types delete evtt_123
 ```
 
 ### Extensions

--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ List, get, edit, and delete events:
 ```
 $ foxglove events list --device-id dev_mHH1Cp4gPybCPR8y --event-type-id evtt_123
 $ foxglove events get evt_idMGJImlICYP4dcy
-$ foxglove events edit evt_idMGJImlICYP4dcy --metadata note:updated --property severity:high
+$ foxglove events edit evt_idMGJImlICYP4dcy --property severity:high
+$ foxglove events edit evt_idMGJImlICYP4dcy --remove-property severity
+$ foxglove events edit evt_idMGJImlICYP4dcy --clear-metadata
 $ foxglove events delete evt_idMGJImlICYP4dcy
 ```
 
@@ -199,6 +201,7 @@ List, get, edit, and delete event types:
 $ foxglove event-types list
 $ foxglove event-types get evtt_123
 $ foxglove event-types edit evtt_123 --name Fault --color-name orange
+$ foxglove event-types edit evtt_123 --clear-custom-properties
 $ foxglove event-types delete evtt_123
 ```
 

--- a/README.md
+++ b/README.md
@@ -188,11 +188,11 @@ $ foxglove events delete evt_idMGJImlICYP4dcy
 
 ### Event types
 
-Create event types with a color and an ordered list of custom properties:
+Create event types with a color and an ordered list of properties:
 
 ```
 $ foxglove event-types add --name "Hardware Fault" --color-name red \
-    --custom-property cprop_abc:true
+    --property cprop_abc:true
 ```
 
 List, get, edit, and delete event types:
@@ -201,7 +201,7 @@ List, get, edit, and delete event types:
 $ foxglove event-types list
 $ foxglove event-types get evtt_123
 $ foxglove event-types edit evtt_123 --name Fault --color-name orange
-$ foxglove event-types edit evtt_123 --clear-custom-properties
+$ foxglove event-types edit evtt_123 --clear-properties
 $ foxglove event-types delete evtt_123
 ```
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ List, get, edit, and delete events:
 ```
 $ foxglove events list --device-id dev_mHH1Cp4gPybCPR8y --event-type-id evtt_123
 $ foxglove events get evt_idMGJImlICYP4dcy
-$ foxglove events edit evt_idMGJImlICYP4dcy --metadata note:updated
+$ foxglove events edit evt_idMGJImlICYP4dcy --metadata note:updated --property severity:high
 $ foxglove events delete evt_idMGJImlICYP4dcy
 ```
 

--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -423,17 +423,22 @@ func (r ImportsResponse) Headers() []string {
 }
 
 type EventsRequest struct {
-	DeviceID    string   `json:"device.id" form:"device.id,omitempty"`
-	DeviceName  string   `json:"device.name" form:"device.name,omitempty"`
-	End         string   `json:"end" form:"end,omitempty"`
-	EventTypeID string   `json:"eventTypeId" form:"eventTypeId,omitempty"`
-	Limit       int      `json:"limit" form:"limit,omitempty"`
-	Offset      int      `json:"offset" form:"offset,omitempty"`
-	Query       string   `json:"query" form:"query,omitempty"`
-	QueryFields []string `json:"queryFields" form:"queryFields,omitempty"`
-	SortBy      string   `json:"sortBy" form:"sortBy,omitempty"`
-	SortOrder   string   `json:"sortOrder" form:"sortOrder,omitempty"`
-	Start       string   `json:"start" form:"start,omitempty"`
+	CreatedAfter string `json:"createdAfter" form:"createdAfter,omitempty"`
+	DeviceID     string `json:"deviceId" form:"deviceId,omitempty"`
+	DeviceName   string `json:"deviceName" form:"deviceName,omitempty"`
+	End          string `json:"end" form:"end,omitempty"`
+	EventID      string `json:"eventId" form:"eventId,omitempty"`
+	EventTypeID  string `json:"eventTypeId" form:"eventTypeId,omitempty"`
+	Limit        int    `json:"limit" form:"limit,omitempty"`
+	Offset       int    `json:"offset" form:"offset,omitempty"`
+	ProjectID    string `json:"projectId" form:"projectId,omitempty"`
+	Query        string `json:"query" form:"query,omitempty"`
+	// QueryFields is a comma-separated list of "metadata" and/or "properties".
+	QueryFields  string `json:"queryFields" form:"queryFields,omitempty"`
+	SortBy       string `json:"sortBy" form:"sortBy,omitempty"`
+	SortOrder    string `json:"sortOrder" form:"sortOrder,omitempty"`
+	Start        string `json:"start" form:"start,omitempty"`
+	UpdatedAfter string `json:"updatedAfter" form:"updatedAfter,omitempty"`
 }
 
 type EventResponseItem struct {
@@ -652,41 +657,49 @@ type PatchSessionRecordingsRequest struct {
 }
 
 type CreateEventRequest struct {
-	DeviceID    string            `json:"deviceId"`
-	End         string            `json:"end"`
-	EventTypeID string            `json:"eventTypeId,omitempty"`
-	Metadata    map[string]string `json:"metadata"`
-	Start       string            `json:"start"`
+	DeviceID    string                 `json:"deviceId,omitempty"`
+	DeviceName  string                 `json:"deviceName,omitempty"`
+	End         string                 `json:"end"`
+	EventTypeID string                 `json:"eventTypeId,omitempty"`
+	Metadata    map[string]string      `json:"metadata"`
+	ProjectID   string                 `json:"projectId,omitempty"`
+	Properties  map[string]interface{} `json:"properties,omitempty"`
+	Start       string                 `json:"start"`
 }
 
 type CreateEventResponse = EventResponseItem
 
+type UpdateEventRequest struct {
+	End         string                 `json:"end,omitempty"`
+	EventTypeID *string                `json:"eventTypeId,omitempty"`
+	Metadata    map[string]string      `json:"metadata,omitempty"`
+	Properties  map[string]interface{} `json:"properties,omitempty"`
+	Start       string                 `json:"start,omitempty"`
+}
+
 type EventTypesRequest struct{}
 
-type EventTypePropertyDefinition struct {
-	Key       string   `json:"key"`
-	Label     string   `json:"label"`
-	Required  bool     `json:"required"`
-	Values    []string `json:"values,omitempty"`
-	ValueType string   `json:"valueType"`
+type EventTypeCustomProperty struct {
+	ID       string `json:"id"`
+	Required bool   `json:"required"`
 }
 
 type EventTypeResponse struct {
-	ColorName  string                        `json:"colorName"`
-	CreatedAt  string                        `json:"createdAt"`
-	ID         string                        `json:"id"`
-	Name       string                        `json:"name"`
-	Properties []EventTypePropertyDefinition `json:"properties"`
-	UpdatedAt  string                        `json:"updatedAt"`
+	ColorName        string                    `json:"colorName"`
+	CreatedAt        string                    `json:"createdAt"`
+	CustomProperties []EventTypeCustomProperty `json:"customProperties"`
+	ID               string                    `json:"id"`
+	Name             string                    `json:"name"`
+	UpdatedAt        string                    `json:"updatedAt"`
 }
 
 func (r EventTypeResponse) Fields() []string {
-	properties, _ := json.Marshal(r.Properties)
+	customProperties, _ := json.Marshal(r.CustomProperties)
 	return []string{
 		r.ID,
 		r.Name,
 		r.ColorName,
-		string(properties),
+		string(customProperties),
 		r.CreatedAt,
 		r.UpdatedAt,
 	}
@@ -697,10 +710,22 @@ func (r EventTypeResponse) Headers() []string {
 		"ID",
 		"Name",
 		"Color",
-		"Properties",
+		"Custom Properties",
 		"Created At",
 		"Updated At",
 	}
+}
+
+type CreateEventTypeRequest struct {
+	ColorName        string                    `json:"colorName,omitempty"`
+	CustomProperties []EventTypeCustomProperty `json:"customProperties"`
+	Name             string                    `json:"name"`
+}
+
+type UpdateEventTypeRequest struct {
+	ColorName        string                     `json:"colorName,omitempty"`
+	CustomProperties *[]EventTypeCustomProperty `json:"customProperties,omitempty"`
+	Name             string                     `json:"name,omitempty"`
 }
 
 type ExtensionsRequest struct{}
@@ -720,6 +745,7 @@ type CustomPropertiesRequest struct {
 }
 
 type CustomPropertiesResponseItem struct {
+	ID           string   `json:"id"`
 	Key          string   `json:"key"`
 	Label        string   `json:"label"`
 	ResourceType string   `json:"resourceType"`

--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -741,7 +741,7 @@ type ExtensionResponse struct {
 }
 
 type CustomPropertiesRequest struct {
-	ResourceType string `json:"resourceType"`
+	ResourceType string `json:"resourceType" form:"resourceType,omitempty"`
 }
 
 type CustomPropertiesResponseItem struct {

--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -672,7 +672,7 @@ type CreateEventResponse = EventResponseItem
 type UpdateEventRequest struct {
 	End         string                 `json:"end,omitempty"`
 	EventTypeID *string                `json:"eventTypeId,omitempty"`
-	Metadata    map[string]string      `json:"metadata,omitempty"`
+	Metadata    *map[string]string     `json:"metadata,omitempty"`
 	Properties  map[string]interface{} `json:"properties,omitempty"`
 	Start       string                 `json:"start,omitempty"`
 }
@@ -751,6 +751,7 @@ type CustomPropertiesResponseItem struct {
 	ResourceType string   `json:"resourceType"`
 	ValueType    string   `json:"valueType"`
 	Values       []string `json:"values"`
+	EnumValues   []string `json:"enumValues"`
 }
 
 func (r ExtensionResponse) Fields() []string {

--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -693,9 +693,10 @@ type EventTypeResponse struct {
 	UpdatedAt  string                    `json:"updatedAt"`
 }
 
-// eventTypeAPIResponse mirrors the public API wire format. Event type
-// properties are exposed as "properties" by the CLI for backwards
-// compatibility, while the API calls the field "customProperties".
+// eventTypeAPIResponse is the public /v1/event-types JSON body.
+// The API field is customProperties: [{id, required}]. CLI JSON and table
+// output use the name "properties" for that same list. The name is for
+// compatibility with the previous CLI field; the item shape is not.
 type eventTypeAPIResponse struct {
 	ColorName        string                    `json:"colorName"`
 	CreatedAt        string                    `json:"createdAt"`

--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -685,6 +685,18 @@ type EventTypeCustomProperty struct {
 }
 
 type EventTypeResponse struct {
+	ColorName  string                    `json:"colorName"`
+	CreatedAt  string                    `json:"createdAt"`
+	ID         string                    `json:"id"`
+	Name       string                    `json:"name"`
+	Properties []EventTypeCustomProperty `json:"properties"`
+	UpdatedAt  string                    `json:"updatedAt"`
+}
+
+// eventTypeAPIResponse mirrors the public API wire format. Event type
+// properties are exposed as "properties" by the CLI for backwards
+// compatibility, while the API calls the field "customProperties".
+type eventTypeAPIResponse struct {
 	ColorName        string                    `json:"colorName"`
 	CreatedAt        string                    `json:"createdAt"`
 	CustomProperties []EventTypeCustomProperty `json:"customProperties"`
@@ -693,13 +705,35 @@ type EventTypeResponse struct {
 	UpdatedAt        string                    `json:"updatedAt"`
 }
 
+func (r eventTypeAPIResponse) cliResponse() EventTypeResponse {
+	return EventTypeResponse{
+		ColorName:  r.ColorName,
+		CreatedAt:  r.CreatedAt,
+		ID:         r.ID,
+		Name:       r.Name,
+		Properties: r.CustomProperties,
+		UpdatedAt:  r.UpdatedAt,
+	}
+}
+
+func eventTypeWireResponse(r EventTypeResponse) eventTypeAPIResponse {
+	return eventTypeAPIResponse{
+		ColorName:        r.ColorName,
+		CreatedAt:        r.CreatedAt,
+		CustomProperties: r.Properties,
+		ID:               r.ID,
+		Name:             r.Name,
+		UpdatedAt:        r.UpdatedAt,
+	}
+}
+
 func (r EventTypeResponse) Fields() []string {
-	customProperties, _ := json.Marshal(r.CustomProperties)
+	properties, _ := json.Marshal(r.Properties)
 	return []string{
 		r.ID,
 		r.Name,
 		r.ColorName,
-		string(customProperties),
+		string(properties),
 		r.CreatedAt,
 		r.UpdatedAt,
 	}
@@ -710,7 +744,7 @@ func (r EventTypeResponse) Headers() []string {
 		"ID",
 		"Name",
 		"Color",
-		"Custom Properties",
+		"Properties",
 		"Created At",
 		"Updated At",
 	}

--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -434,6 +434,8 @@ type EventsRequest struct {
 	ProjectID    string `json:"projectId" form:"projectId,omitempty"`
 	Query        string `json:"query" form:"query,omitempty"`
 	// QueryFields is a comma-separated list of "metadata" and/or "properties".
+	// Public GET /v1/events documents queryFields with explode: false, so the
+	// query is queryFields=metadata,properties.
 	QueryFields  string `json:"queryFields" form:"queryFields,omitempty"`
 	SortBy       string `json:"sortBy" form:"sortBy,omitempty"`
 	SortOrder    string `json:"sortOrder" form:"sortOrder,omitempty"`

--- a/foxglove/api/api_test.go
+++ b/foxglove/api/api_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -39,17 +40,29 @@ func TestEventTypeResponseFields(t *testing.T) {
 		ID:        "evtt_1",
 		Name:      "Incident",
 		ColorName: "red",
-		CustomProperties: []EventTypeCustomProperty{
+		Properties: []EventTypeCustomProperty{
 			{ID: "cprop_1", Required: true},
 		},
 		CreatedAt: "2024-01-01T00:00:00Z",
 		UpdatedAt: "2024-01-02T00:00:00Z",
 	}
-	assert.Equal(t, []string{"ID", "Name", "Color", "Custom Properties", "Created At", "Updated At"}, resp.Headers())
+	assert.Equal(t, []string{"ID", "Name", "Color", "Properties", "Created At", "Updated At"}, resp.Headers())
 	assert.Equal(t, "evtt_1", resp.Fields()[0])
 	assert.Equal(t, "Incident", resp.Fields()[1])
 	assert.Equal(t, "red", resp.Fields()[2])
 	assert.Contains(t, resp.Fields()[3], "cprop_1")
+
+	encoded, err := json.Marshal(resp)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{
+		"id": "evtt_1",
+		"name": "Incident",
+		"colorName": "red",
+		"properties": [{"id": "cprop_1", "required": true}],
+		"createdAt": "2024-01-01T00:00:00Z",
+		"updatedAt": "2024-01-02T00:00:00Z"
+	}`, string(encoded))
+	assert.NotContains(t, string(encoded), "customProperties")
 }
 
 func TestStreamRequestValidate(t *testing.T) {

--- a/foxglove/api/api_test.go
+++ b/foxglove/api/api_test.go
@@ -34,6 +34,24 @@ func TestRecordingsFields(t *testing.T) {
 	})
 }
 
+func TestEventTypeResponseFields(t *testing.T) {
+	resp := EventTypeResponse{
+		ID:        "evtt_1",
+		Name:      "Incident",
+		ColorName: "red",
+		CustomProperties: []EventTypeCustomProperty{
+			{ID: "cprop_1", Required: true},
+		},
+		CreatedAt: "2024-01-01T00:00:00Z",
+		UpdatedAt: "2024-01-02T00:00:00Z",
+	}
+	assert.Equal(t, []string{"ID", "Name", "Color", "Custom Properties", "Created At", "Updated At"}, resp.Headers())
+	assert.Equal(t, "evtt_1", resp.Fields()[0])
+	assert.Equal(t, "Incident", resp.Fields()[1])
+	assert.Equal(t, "red", resp.Fields()[2])
+	assert.Contains(t, resp.Fields()[3], "cprop_1")
+}
+
 func TestStreamRequestValidate(t *testing.T) {
 	start := time.Now().Add(-time.Hour)
 	end := time.Now()

--- a/foxglove/api/client.go
+++ b/foxglove/api/client.go
@@ -475,7 +475,15 @@ func (c *FoxgloveClient) Events(req *EventsRequest) (resp []EventResponseItem, e
 }
 
 func (c *FoxgloveClient) EventTypes(req *EventTypesRequest) (resp []EventTypeResponse, err error) {
-	err = c.get("/v1/event-types", req, &resp)
+	var wireResp []eventTypeAPIResponse
+	err = c.get("/v1/event-types", req, &wireResp)
+	if err != nil {
+		return nil, err
+	}
+	resp = make([]EventTypeResponse, 0, len(wireResp))
+	for _, eventType := range wireResp {
+		resp = append(resp, eventType.cliResponse())
+	}
 	return resp, err
 }
 
@@ -484,13 +492,15 @@ func (c *FoxgloveClient) GetEventType(id string) (resp EventTypeResponse, err er
 	if err != nil {
 		return EventTypeResponse{}, err
 	}
-	err = c.get(path, struct{}{}, &resp)
-	return resp, err
+	var wireResp eventTypeAPIResponse
+	err = c.get(path, struct{}{}, &wireResp)
+	return wireResp.cliResponse(), err
 }
 
 func (c *FoxgloveClient) CreateEventType(req CreateEventTypeRequest) (resp EventTypeResponse, err error) {
-	err = c.post("/v1/event-types", req, &resp)
-	return resp, err
+	var wireResp eventTypeAPIResponse
+	err = c.post("/v1/event-types", req, &wireResp)
+	return wireResp.cliResponse(), err
 }
 
 func (c *FoxgloveClient) UpdateEventType(id string, req UpdateEventTypeRequest) (resp EventTypeResponse, err error) {
@@ -498,8 +508,9 @@ func (c *FoxgloveClient) UpdateEventType(id string, req UpdateEventTypeRequest) 
 	if err != nil {
 		return EventTypeResponse{}, err
 	}
-	err = c.patch(path, struct{}{}, req, &resp)
-	return resp, err
+	var wireResp eventTypeAPIResponse
+	err = c.patch(path, struct{}{}, req, &wireResp)
+	return wireResp.cliResponse(), err
 }
 
 func (c *FoxgloveClient) DeleteEventType(id string) error {

--- a/foxglove/api/client.go
+++ b/foxglove/api/client.go
@@ -310,6 +310,32 @@ func (c *FoxgloveClient) CreateEvent(req CreateEventRequest) (resp CreateEventRe
 	return resp, err
 }
 
+func (c *FoxgloveClient) GetEvent(id string) (resp EventResponseItem, err error) {
+	path, err := url.JoinPath("/v1/events", id)
+	if err != nil {
+		return EventResponseItem{}, err
+	}
+	err = c.get(path, struct{}{}, &resp)
+	return resp, err
+}
+
+func (c *FoxgloveClient) UpdateEvent(id string, req UpdateEventRequest) (resp EventResponseItem, err error) {
+	path, err := url.JoinPath("/v1/events", id)
+	if err != nil {
+		return EventResponseItem{}, err
+	}
+	err = c.patch(path, struct{}{}, req, &resp)
+	return resp, err
+}
+
+func (c *FoxgloveClient) DeleteEvent(id string) error {
+	path, err := url.JoinPath("/v1/events", id)
+	if err != nil {
+		return err
+	}
+	return c.delete(path)
+}
+
 // UploadExtension sends the contents of a reader to the extension-upload endpoint.
 // This endpoint  can be used to create an extension, or update with a new version.
 // Extension & version information is parsed from the extension's package.json.
@@ -451,6 +477,37 @@ func (c *FoxgloveClient) Events(req *EventsRequest) (resp []EventResponseItem, e
 func (c *FoxgloveClient) EventTypes(req *EventTypesRequest) (resp []EventTypeResponse, err error) {
 	err = c.get("/v1/event-types", req, &resp)
 	return resp, err
+}
+
+func (c *FoxgloveClient) GetEventType(id string) (resp EventTypeResponse, err error) {
+	path, err := url.JoinPath("/v1/event-types", id)
+	if err != nil {
+		return EventTypeResponse{}, err
+	}
+	err = c.get(path, struct{}{}, &resp)
+	return resp, err
+}
+
+func (c *FoxgloveClient) CreateEventType(req CreateEventTypeRequest) (resp EventTypeResponse, err error) {
+	err = c.post("/v1/event-types", req, &resp)
+	return resp, err
+}
+
+func (c *FoxgloveClient) UpdateEventType(id string, req UpdateEventTypeRequest) (resp EventTypeResponse, err error) {
+	path, err := url.JoinPath("/v1/event-types", id)
+	if err != nil {
+		return EventTypeResponse{}, err
+	}
+	err = c.patch(path, struct{}{}, req, &resp)
+	return resp, err
+}
+
+func (c *FoxgloveClient) DeleteEventType(id string) error {
+	path, err := url.JoinPath("/v1/event-types", id)
+	if err != nil {
+		return err
+	}
+	return c.delete(path)
 }
 
 func (c *FoxgloveClient) Imports(req *ImportsRequest) (resp []ImportsResponse, err error) {

--- a/foxglove/api/mock_service.go
+++ b/foxglove/api/mock_service.go
@@ -393,6 +393,14 @@ func (s *MockFoxgloveServer) createEvent(w http.ResponseWriter, r *http.Request)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
+	if req.EventTypeID != "" && len(req.Metadata) > 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if req.EventTypeID == "" && len(req.Properties) > 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 	id, _ := randomString(8)
 	device := DeviceSummary{ID: req.DeviceID, Name: req.DeviceName}
 	if device.ID == "" && device.Name != "" {
@@ -468,7 +476,7 @@ func (s *MockFoxgloveServer) patchEvent(w http.ResponseWriter, r *http.Request) 
 		event.End = req.End
 	}
 	if req.Metadata != nil {
-		event.Metadata = req.Metadata
+		event.Metadata = *req.Metadata
 	}
 	if req.EventTypeID != nil {
 		event.EventTypeID = *req.EventTypeID
@@ -829,8 +837,8 @@ func mockServer(port int) *MockFoxgloveServer {
 			{ID: "cprop_bool", Key: "bool", ResourceType: "device", Label: "", ValueType: "boolean"},
 			{ID: "cprop_enum", Key: "enum", ResourceType: "device", Label: "", ValueType: "enum", Values: []string{"foo", "bar"}},
 			{ID: "cprop_evt_str", Key: "severity", ResourceType: "event", Label: "Severity", ValueType: "string"},
-			{ID: "cprop_evt_enum", Key: "status", ResourceType: "event", Label: "Status", ValueType: "enum", Values: []string{"open", "closed"}},
-			{ID: "cprop_evt_multi", Key: "tags", ResourceType: "event", Label: "Tags", ValueType: "multi-enum", Values: []string{"a", "b", "c"}},
+			{ID: "cprop_evt_enum", Key: "status", ResourceType: "event", Label: "Status", ValueType: "enum", EnumValues: []string{"open", "closed"}},
+			{ID: "cprop_evt_multi", Key: "tags", ResourceType: "event", Label: "Tags", ValueType: "multi-enum", EnumValues: []string{"a", "b", "c"}},
 		},
 	}
 }

--- a/foxglove/api/mock_service.go
+++ b/foxglove/api/mock_service.go
@@ -359,7 +359,6 @@ func (s *MockFoxgloveServer) eventsList(w http.ResponseWriter, r *http.Request) 
 	filterDeviceName := q.Get("deviceName")
 	filterEventID := q.Get("eventId")
 	filterEventTypeID := q.Get("eventTypeId")
-	filterProjectID := q.Get("projectId")
 
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
@@ -375,9 +374,6 @@ func (s *MockFoxgloveServer) eventsList(w http.ResponseWriter, r *http.Request) 
 			continue
 		}
 		if filterEventTypeID != "" && event.EventTypeID != filterEventTypeID {
-			continue
-		}
-		if filterProjectID != "" && event.Device.ID == "" {
 			continue
 		}
 		out = append(out, event)

--- a/foxglove/api/mock_service.go
+++ b/foxglove/api/mock_service.go
@@ -26,6 +26,8 @@ type MockFoxgloveServer struct {
 	registeredDevices    []DevicesResponse
 	registeredSessions   []SessionResponse
 	registeredProperties []CustomPropertiesResponseItem
+	registeredEvents     []EventResponseItem
+	registeredEventTypes []EventTypeResponse
 	tokenRequests        int
 	port                 int
 }
@@ -351,6 +353,258 @@ func (s *MockFoxgloveServer) patchSession(w http.ResponseWriter, r *http.Request
 	w.WriteHeader(http.StatusNotFound)
 }
 
+func (s *MockFoxgloveServer) eventsList(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	filterDeviceID := q.Get("deviceId")
+	filterDeviceName := q.Get("deviceName")
+	filterEventID := q.Get("eventId")
+	filterEventTypeID := q.Get("eventTypeId")
+	filterProjectID := q.Get("projectId")
+
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	out := make([]EventResponseItem, 0, len(s.registeredEvents))
+	for _, event := range s.registeredEvents {
+		if filterDeviceID != "" && event.Device.ID != filterDeviceID {
+			continue
+		}
+		if filterDeviceName != "" && event.Device.Name != filterDeviceName {
+			continue
+		}
+		if filterEventID != "" && event.ID != filterEventID {
+			continue
+		}
+		if filterEventTypeID != "" && event.EventTypeID != filterEventTypeID {
+			continue
+		}
+		if filterProjectID != "" && event.Device.ID == "" {
+			continue
+		}
+		out = append(out, event)
+	}
+	if err := json.NewEncoder(w).Encode(out); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func (s *MockFoxgloveServer) createEvent(w http.ResponseWriter, r *http.Request) {
+	req := CreateEventRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if req.Start == "" || req.End == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	id, _ := randomString(8)
+	device := DeviceSummary{ID: req.DeviceID, Name: req.DeviceName}
+	if device.ID == "" && device.Name != "" {
+		if found := s.lookupDevice("", device.Name); found != nil {
+			device.ID = found.ID
+			device.Name = found.Name
+		}
+	}
+	if device.Name == "" && device.ID != "" {
+		if found := s.lookupDevice(device.ID, ""); found != nil {
+			device.Name = found.Name
+		}
+	}
+	event := EventResponseItem{
+		ID:          "evt_" + id,
+		Device:      device,
+		Start:       req.Start,
+		End:         req.End,
+		EventTypeID: req.EventTypeID,
+		Metadata:    req.Metadata,
+		Properties:  req.Properties,
+		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt:   time.Now().UTC().Format(time.RFC3339),
+	}
+	if event.Metadata == nil {
+		event.Metadata = map[string]string{}
+	}
+	s.mtx.Lock()
+	s.registeredEvents = append(s.registeredEvents, event)
+	s.mtx.Unlock()
+	_ = json.NewEncoder(w).Encode(event)
+}
+
+func (s *MockFoxgloveServer) findEvent(id string) (int, *EventResponseItem) {
+	for i := range s.registeredEvents {
+		if s.registeredEvents[i].ID == id {
+			return i, &s.registeredEvents[i]
+		}
+	}
+	return -1, nil
+}
+
+func (s *MockFoxgloveServer) getEvent(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	_, event := s.findEvent(id)
+	if event == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(event)
+}
+
+func (s *MockFoxgloveServer) patchEvent(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	req := UpdateEventRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	idx, event := s.findEvent(id)
+	if event == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	if req.Start != "" {
+		event.Start = req.Start
+	}
+	if req.End != "" {
+		event.End = req.End
+	}
+	if req.Metadata != nil {
+		event.Metadata = req.Metadata
+	}
+	if req.EventTypeID != nil {
+		event.EventTypeID = *req.EventTypeID
+	}
+	if req.Properties != nil {
+		if event.Properties == nil {
+			event.Properties = map[string]interface{}{}
+		}
+		for key, value := range req.Properties {
+			if value == nil {
+				delete(event.Properties, key)
+				continue
+			}
+			event.Properties[key] = value
+		}
+	}
+	event.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	s.registeredEvents[idx] = *event
+	_ = json.NewEncoder(w).Encode(event)
+}
+
+func (s *MockFoxgloveServer) deleteEvent(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	idx, _ := s.findEvent(id)
+	if idx < 0 {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	s.registeredEvents = append(s.registeredEvents[:idx], s.registeredEvents[idx+1:]...)
+	_ = json.NewEncoder(w).Encode(map[string]string{"id": id})
+}
+
+func (s *MockFoxgloveServer) eventTypesList(w http.ResponseWriter, r *http.Request) {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	if err := json.NewEncoder(w).Encode(s.registeredEventTypes); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func (s *MockFoxgloveServer) createEventType(w http.ResponseWriter, r *http.Request) {
+	req := CreateEventTypeRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if req.Name == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if req.CustomProperties == nil {
+		req.CustomProperties = []EventTypeCustomProperty{}
+	}
+	id, _ := randomString(8)
+	eventType := EventTypeResponse{
+		ID:               "evtt_" + id,
+		Name:             req.Name,
+		ColorName:        req.ColorName,
+		CustomProperties: req.CustomProperties,
+		CreatedAt:        time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt:        time.Now().UTC().Format(time.RFC3339),
+	}
+	s.mtx.Lock()
+	s.registeredEventTypes = append(s.registeredEventTypes, eventType)
+	s.mtx.Unlock()
+	_ = json.NewEncoder(w).Encode(eventType)
+}
+
+func (s *MockFoxgloveServer) findEventType(id string) (int, *EventTypeResponse) {
+	for i := range s.registeredEventTypes {
+		if s.registeredEventTypes[i].ID == id {
+			return i, &s.registeredEventTypes[i]
+		}
+	}
+	return -1, nil
+}
+
+func (s *MockFoxgloveServer) getEventType(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	_, eventType := s.findEventType(id)
+	if eventType == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(eventType)
+}
+
+func (s *MockFoxgloveServer) patchEventType(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	req := UpdateEventTypeRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	idx, eventType := s.findEventType(id)
+	if eventType == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	if req.Name != "" {
+		eventType.Name = req.Name
+	}
+	if req.ColorName != "" {
+		eventType.ColorName = req.ColorName
+	}
+	if req.CustomProperties != nil {
+		eventType.CustomProperties = *req.CustomProperties
+	}
+	eventType.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	s.registeredEventTypes[idx] = *eventType
+	_ = json.NewEncoder(w).Encode(eventType)
+}
+
+func (s *MockFoxgloveServer) deleteEventType(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	idx, _ := s.findEventType(id)
+	if idx < 0 {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	s.registeredEventTypes = append(s.registeredEventTypes[:idx], s.registeredEventTypes[idx+1:]...)
+	_ = json.NewEncoder(w).Encode(map[string]string{"id": id})
+}
+
 func (s *MockFoxgloveServer) deleteSession(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	s.mtx.Lock()
@@ -486,7 +740,18 @@ func (s *MockFoxgloveServer) ValidExtensionId() string {
 func (s *MockFoxgloveServer) customProperties(w http.ResponseWriter, r *http.Request) {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
-	err := json.NewEncoder(w).Encode(s.registeredProperties)
+	resourceType := r.URL.Query().Get("resourceType")
+	out := s.registeredProperties
+	if resourceType != "" {
+		filtered := make([]CustomPropertiesResponseItem, 0, len(out))
+		for _, prop := range out {
+			if prop.ResourceType == resourceType {
+				filtered = append(filtered, prop)
+			}
+		}
+		out = filtered
+	}
+	err := json.NewEncoder(w).Encode(out)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 	}
@@ -551,11 +816,25 @@ func mockServer(port int) *MockFoxgloveServer {
 			},
 		},
 		registeredSessions: []SessionResponse{},
+		registeredEvents:   []EventResponseItem{},
+		registeredEventTypes: []EventTypeResponse{
+			{
+				ID:               "evtt_default",
+				Name:             "Incident",
+				ColorName:        "red",
+				CustomProperties: []EventTypeCustomProperty{},
+				CreatedAt:        time.Now().UTC().Format(time.RFC3339),
+				UpdatedAt:        time.Now().UTC().Format(time.RFC3339),
+			},
+		},
 		registeredProperties: []CustomPropertiesResponseItem{
-			{Key: "str", ResourceType: "devices", Label: "", ValueType: "string"},
-			{Key: "num", ResourceType: "devices", Label: "", ValueType: "number"},
-			{Key: "bool", ResourceType: "devices", Label: "", ValueType: "boolean"},
-			{Key: "enum", ResourceType: "devices", Label: "", ValueType: "enum", Values: []string{"foo", "bar"}},
+			{ID: "cprop_str", Key: "str", ResourceType: "device", Label: "", ValueType: "string"},
+			{ID: "cprop_num", Key: "num", ResourceType: "device", Label: "", ValueType: "number"},
+			{ID: "cprop_bool", Key: "bool", ResourceType: "device", Label: "", ValueType: "boolean"},
+			{ID: "cprop_enum", Key: "enum", ResourceType: "device", Label: "", ValueType: "enum", Values: []string{"foo", "bar"}},
+			{ID: "cprop_evt_str", Key: "severity", ResourceType: "event", Label: "Severity", ValueType: "string"},
+			{ID: "cprop_evt_enum", Key: "status", ResourceType: "event", Label: "Status", ValueType: "enum", Values: []string{"open", "closed"}},
+			{ID: "cprop_evt_multi", Key: "tags", ResourceType: "event", Label: "Tags", ValueType: "multi-enum", Values: []string{"a", "b", "c"}},
 		},
 	}
 }
@@ -582,6 +861,16 @@ func makeRoutes(sv *MockFoxgloveServer) *mux.Router {
 	r.HandleFunc("/v1/sessions/{id}", sv.withAuthz(sv.getSession)).Methods("GET")
 	r.HandleFunc("/v1/sessions/{id}", sv.withAuthz(sv.patchSession)).Methods("PATCH")
 	r.HandleFunc("/v1/sessions/{id}", sv.withAuthz(sv.deleteSession)).Methods("DELETE")
+	r.HandleFunc("/v1/events", sv.withAuthz(sv.eventsList)).Methods("GET")
+	r.HandleFunc("/v1/events", sv.withAuthz(sv.createEvent)).Methods("POST")
+	r.HandleFunc("/v1/events/{id}", sv.withAuthz(sv.getEvent)).Methods("GET")
+	r.HandleFunc("/v1/events/{id}", sv.withAuthz(sv.patchEvent)).Methods("PATCH")
+	r.HandleFunc("/v1/events/{id}", sv.withAuthz(sv.deleteEvent)).Methods("DELETE")
+	r.HandleFunc("/v1/event-types", sv.withAuthz(sv.eventTypesList)).Methods("GET")
+	r.HandleFunc("/v1/event-types", sv.withAuthz(sv.createEventType)).Methods("POST")
+	r.HandleFunc("/v1/event-types/{id}", sv.withAuthz(sv.getEventType)).Methods("GET")
+	r.HandleFunc("/v1/event-types/{id}", sv.withAuthz(sv.patchEventType)).Methods("PATCH")
+	r.HandleFunc("/v1/event-types/{id}", sv.withAuthz(sv.deleteEventType)).Methods("DELETE")
 	r.HandleFunc("/v1/projects", sv.withAuthz(sv.projects)).Methods("GET")
 	r.HandleFunc("/v1/extension-upload", sv.withAuthz(sv.uploadExtension)).Methods("POST")
 	r.HandleFunc("/v1/extensions", sv.withAuthz(sv.listExtensions)).Methods("GET")

--- a/foxglove/api/mock_service.go
+++ b/foxglove/api/mock_service.go
@@ -397,7 +397,7 @@ func (s *MockFoxgloveServer) createEvent(w http.ResponseWriter, r *http.Request)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	if req.EventTypeID == "" && len(req.Properties) > 0 {
+	if len(req.Metadata) > 0 && len(req.Properties) > 0 {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -514,7 +514,11 @@ func (s *MockFoxgloveServer) deleteEvent(w http.ResponseWriter, r *http.Request)
 func (s *MockFoxgloveServer) eventTypesList(w http.ResponseWriter, r *http.Request) {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
-	if err := json.NewEncoder(w).Encode(s.registeredEventTypes); err != nil {
+	eventTypes := make([]eventTypeAPIResponse, 0, len(s.registeredEventTypes))
+	for _, eventType := range s.registeredEventTypes {
+		eventTypes = append(eventTypes, eventTypeWireResponse(eventType))
+	}
+	if err := json.NewEncoder(w).Encode(eventTypes); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 }
@@ -534,17 +538,17 @@ func (s *MockFoxgloveServer) createEventType(w http.ResponseWriter, r *http.Requ
 	}
 	id, _ := randomString(8)
 	eventType := EventTypeResponse{
-		ID:               "evtt_" + id,
-		Name:             req.Name,
-		ColorName:        req.ColorName,
-		CustomProperties: req.CustomProperties,
-		CreatedAt:        time.Now().UTC().Format(time.RFC3339),
-		UpdatedAt:        time.Now().UTC().Format(time.RFC3339),
+		ID:         "evtt_" + id,
+		Name:       req.Name,
+		ColorName:  req.ColorName,
+		Properties: req.CustomProperties,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt:  time.Now().UTC().Format(time.RFC3339),
 	}
 	s.mtx.Lock()
 	s.registeredEventTypes = append(s.registeredEventTypes, eventType)
 	s.mtx.Unlock()
-	_ = json.NewEncoder(w).Encode(eventType)
+	_ = json.NewEncoder(w).Encode(eventTypeWireResponse(eventType))
 }
 
 func (s *MockFoxgloveServer) findEventType(id string) (int, *EventTypeResponse) {
@@ -565,7 +569,7 @@ func (s *MockFoxgloveServer) getEventType(w http.ResponseWriter, r *http.Request
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-	_ = json.NewEncoder(w).Encode(eventType)
+	_ = json.NewEncoder(w).Encode(eventTypeWireResponse(*eventType))
 }
 
 func (s *MockFoxgloveServer) patchEventType(w http.ResponseWriter, r *http.Request) {
@@ -589,11 +593,11 @@ func (s *MockFoxgloveServer) patchEventType(w http.ResponseWriter, r *http.Reque
 		eventType.ColorName = req.ColorName
 	}
 	if req.CustomProperties != nil {
-		eventType.CustomProperties = *req.CustomProperties
+		eventType.Properties = *req.CustomProperties
 	}
 	eventType.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 	s.registeredEventTypes[idx] = *eventType
-	_ = json.NewEncoder(w).Encode(eventType)
+	_ = json.NewEncoder(w).Encode(eventTypeWireResponse(*eventType))
 }
 
 func (s *MockFoxgloveServer) deleteEventType(w http.ResponseWriter, r *http.Request) {
@@ -823,12 +827,12 @@ func mockServer(port int) *MockFoxgloveServer {
 		registeredEvents:   []EventResponseItem{},
 		registeredEventTypes: []EventTypeResponse{
 			{
-				ID:               "evtt_default",
-				Name:             "Incident",
-				ColorName:        "red",
-				CustomProperties: []EventTypeCustomProperty{},
-				CreatedAt:        time.Now().UTC().Format(time.RFC3339),
-				UpdatedAt:        time.Now().UTC().Format(time.RFC3339),
+				ID:         "evtt_default",
+				Name:       "Incident",
+				ColorName:  "red",
+				Properties: []EventTypeCustomProperty{},
+				CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+				UpdatedAt:  time.Now().UTC().Format(time.RFC3339),
 			},
 		},
 		registeredProperties: []CustomPropertiesResponseItem{

--- a/foxglove/cmd/devices.go
+++ b/foxglove/cmd/devices.go
@@ -83,7 +83,7 @@ func newAddDeviceCommand(params *baseParams) *cobra.Command {
 	addDeviceCmd.PersistentFlags().StringVarP(&name, "name", "", "", "name of the device")
 	addDeviceCmd.PersistentFlags().StringVarP(&projectID, "project-id", "", viper.GetString("default_project_id"), "Project ID")
 	addDeviceCmd.PersistentFlags().StringVarP(&serialNumber, "serial-number", "", "", "Deprecated. Value will be ignored.")
-	addDeviceCmd.PersistentFlags().StringArrayVarP(&propertyPairs, "property", "p", []string{}, "Custom property colon-separated key value pair. Multiple may be specified.")
+	addDeviceCmd.PersistentFlags().StringArrayVarP(&propertyPairs, "property", "p", []string{}, "Property colon-separated key value pair. Multiple may be specified.")
 	return addDeviceCmd
 }
 
@@ -138,6 +138,6 @@ func newEditDeviceCommand(params *baseParams) *cobra.Command {
 	editDeviceCmd.InheritedFlags()
 	editDeviceCmd.PersistentFlags().StringVarP(&name, "name", "", "", "New name for the device")
 	editDeviceCmd.PersistentFlags().StringVarP(&projectID, "project-id", "", viper.GetString("default_project_id"), "Project ID")
-	editDeviceCmd.PersistentFlags().StringArrayVarP(&propertyPairs, "property", "p", []string{}, "Custom property colon-separated key value pair. Multiple may be specified.")
+	editDeviceCmd.PersistentFlags().StringArrayVarP(&propertyPairs, "property", "p", []string{}, "Property colon-separated key value pair. Multiple may be specified.")
 	return editDeviceCmd
 }

--- a/foxglove/cmd/event_types.go
+++ b/foxglove/cmd/event_types.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func parseEventTypeCustomProperties(pairs []string) ([]api.EventTypeCustomProperty, error) {
+func parseEventTypeProperties(pairs []string) ([]api.EventTypeCustomProperty, error) {
 	customProperties := make([]api.EventTypeCustomProperty, 0, len(pairs))
 	for _, pair := range pairs {
 		id := pair
@@ -19,12 +19,12 @@ func parseEventTypeCustomProperties(pairs []string) ([]api.EventTypeCustomProper
 			id = key
 			parsed, parseErr := strconv.ParseBool(val)
 			if parseErr != nil {
-				return nil, fmt.Errorf("invalid --custom-property value %q: required must be true or false", pair)
+				return nil, fmt.Errorf("invalid --property value %q: required must be true or false", pair)
 			}
 			required = parsed
 		}
 		if id == "" {
-			return nil, fmt.Errorf("invalid --custom-property value %q: custom property ID is required", pair)
+			return nil, fmt.Errorf("invalid --property value %q: property ID is required", pair)
 		}
 		customProperties = append(customProperties, api.EventTypeCustomProperty{
 			ID:       id,
@@ -66,7 +66,7 @@ func newListEventTypesCommand(params *baseParams) *cobra.Command {
 func newAddEventTypeCommand(params *baseParams) *cobra.Command {
 	var name string
 	var colorName string
-	var customPropertyPairs []string
+	var propertyPairs []string
 	addCmd := &cobra.Command{
 		Use:   "add",
 		Short: "Add an event type",
@@ -74,7 +74,7 @@ func newAddEventTypeCommand(params *baseParams) *cobra.Command {
 			if name == "" {
 				dief("--name is required")
 			}
-			customProperties, err := parseEventTypeCustomProperties(customPropertyPairs)
+			properties, err := parseEventTypeProperties(propertyPairs)
 			if err != nil {
 				dief("Failed to add event type: %s", err)
 			}
@@ -86,7 +86,7 @@ func newAddEventTypeCommand(params *baseParams) *cobra.Command {
 			resp, err := client.CreateEventType(api.CreateEventTypeRequest{
 				Name:             name,
 				ColorName:        colorName,
-				CustomProperties: customProperties,
+				CustomProperties: properties,
 			})
 			if err != nil {
 				dief("Failed to add event type: %s", err)
@@ -96,7 +96,7 @@ func newAddEventTypeCommand(params *baseParams) *cobra.Command {
 	}
 	addCmd.PersistentFlags().StringVarP(&name, "name", "", "", "Name of the event type")
 	addCmd.PersistentFlags().StringVarP(&colorName, "color-name", "", "", "Color name of the event type, e.g. red")
-	addCmd.PersistentFlags().StringArrayVarP(&customPropertyPairs, "custom-property", "", []string{}, "Custom property ID, or ID:true/false for required. Multiple may be specified.")
+	addCmd.PersistentFlags().StringArrayVarP(&propertyPairs, "property", "p", []string{}, "Property ID, or ID:true/false for required. Multiple may be specified.")
 	return addCmd
 }
 
@@ -132,15 +132,15 @@ func newGetEventTypeCommand(params *baseParams) *cobra.Command {
 func newEditEventTypeCommand(params *baseParams) *cobra.Command {
 	var name string
 	var colorName string
-	var customPropertyPairs []string
-	var clearCustomProperties bool
+	var propertyPairs []string
+	var clearProperties bool
 	editCmd := &cobra.Command{
 		Use:   "edit [ID]",
 		Short: "Edit an event type",
 		Args:  cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Flags().Changed("custom-property") && clearCustomProperties {
-				return fmt.Errorf("--custom-property and --clear-custom-properties cannot be used together")
+			if cmd.Flags().Changed("property") && clearProperties {
+				return fmt.Errorf("--property and --clear-properties cannot be used together")
 			}
 			return nil
 		},
@@ -152,16 +152,16 @@ func newEditEventTypeCommand(params *baseParams) *cobra.Command {
 			if cmd.Flags().Changed("color-name") {
 				req.ColorName = colorName
 			}
-			if cmd.Flags().Changed("custom-property") {
-				customProperties, err := parseEventTypeCustomProperties(customPropertyPairs)
+			if cmd.Flags().Changed("property") {
+				properties, err := parseEventTypeProperties(propertyPairs)
 				if err != nil {
 					dief("Failed to edit event type: %s", err)
 				}
-				req.CustomProperties = &customProperties
+				req.CustomProperties = &properties
 			}
-			if clearCustomProperties {
-				customProperties := []api.EventTypeCustomProperty{}
-				req.CustomProperties = &customProperties
+			if clearProperties {
+				properties := []api.EventTypeCustomProperty{}
+				req.CustomProperties = &properties
 			}
 			if req.Name == "" && req.ColorName == "" && req.CustomProperties == nil {
 				dief("Nothing to update")
@@ -181,8 +181,8 @@ func newEditEventTypeCommand(params *baseParams) *cobra.Command {
 	editCmd.InheritedFlags()
 	editCmd.PersistentFlags().StringVarP(&name, "name", "", "", "Name of the event type")
 	editCmd.PersistentFlags().StringVarP(&colorName, "color-name", "", "", "Color name of the event type, e.g. red")
-	editCmd.PersistentFlags().StringArrayVarP(&customPropertyPairs, "custom-property", "", []string{}, "Custom property ID, or ID:true/false for required. Replaces the current list. Multiple may be specified.")
-	editCmd.PersistentFlags().BoolVarP(&clearCustomProperties, "clear-custom-properties", "", false, "Remove all custom properties from the event type.")
+	editCmd.PersistentFlags().StringArrayVarP(&propertyPairs, "property", "p", []string{}, "Property ID, or ID:true/false for required. Replaces the current list. Multiple may be specified.")
+	editCmd.PersistentFlags().BoolVarP(&clearProperties, "clear-properties", "", false, "Remove all properties from the event type.")
 	return editCmd
 }
 

--- a/foxglove/cmd/event_types.go
+++ b/foxglove/cmd/event_types.go
@@ -133,10 +133,17 @@ func newEditEventTypeCommand(params *baseParams) *cobra.Command {
 	var name string
 	var colorName string
 	var customPropertyPairs []string
+	var clearCustomProperties bool
 	editCmd := &cobra.Command{
 		Use:   "edit [ID]",
 		Short: "Edit an event type",
 		Args:  cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("custom-property") && clearCustomProperties {
+				return fmt.Errorf("--custom-property and --clear-custom-properties cannot be used together")
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			req := api.UpdateEventTypeRequest{}
 			if cmd.Flags().Changed("name") {
@@ -150,6 +157,10 @@ func newEditEventTypeCommand(params *baseParams) *cobra.Command {
 				if err != nil {
 					dief("Failed to edit event type: %s", err)
 				}
+				req.CustomProperties = &customProperties
+			}
+			if clearCustomProperties {
+				customProperties := []api.EventTypeCustomProperty{}
 				req.CustomProperties = &customProperties
 			}
 			if req.Name == "" && req.ColorName == "" && req.CustomProperties == nil {
@@ -171,6 +182,7 @@ func newEditEventTypeCommand(params *baseParams) *cobra.Command {
 	editCmd.PersistentFlags().StringVarP(&name, "name", "", "", "Name of the event type")
 	editCmd.PersistentFlags().StringVarP(&colorName, "color-name", "", "", "Color name of the event type, e.g. red")
 	editCmd.PersistentFlags().StringArrayVarP(&customPropertyPairs, "custom-property", "", []string{}, "Custom property ID, or ID:true/false for required. Replaces the current list. Multiple may be specified.")
+	editCmd.PersistentFlags().BoolVarP(&clearCustomProperties, "clear-custom-properties", "", false, "Remove all custom properties from the event type.")
 	return editCmd
 }
 

--- a/foxglove/cmd/event_types.go
+++ b/foxglove/cmd/event_types.go
@@ -1,11 +1,38 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/foxglove/foxglove-cli/foxglove/api"
+	"github.com/foxglove/foxglove-cli/foxglove/util"
 	"github.com/spf13/cobra"
 )
+
+func parseEventTypeCustomProperties(pairs []string) ([]api.EventTypeCustomProperty, error) {
+	customProperties := make([]api.EventTypeCustomProperty, 0, len(pairs))
+	for _, pair := range pairs {
+		id := pair
+		required := false
+		if key, val, err := util.SplitPair(pair, ':'); err == nil {
+			id = key
+			parsed, parseErr := strconv.ParseBool(val)
+			if parseErr != nil {
+				return nil, fmt.Errorf("invalid --custom-property value %q: required must be true or false", pair)
+			}
+			required = parsed
+		}
+		if id == "" {
+			return nil, fmt.Errorf("invalid --custom-property value %q: custom property ID is required", pair)
+		}
+		customProperties = append(customProperties, api.EventTypeCustomProperty{
+			ID:       id,
+			Required: required,
+		})
+	}
+	return customProperties, nil
+}
 
 func newListEventTypesCommand(params *baseParams) *cobra.Command {
 	var format string
@@ -34,4 +61,151 @@ func newListEventTypesCommand(params *baseParams) *cobra.Command {
 	AddFormatFlag(cmd, &format)
 	AddJsonFlag(cmd, &isJsonFormat)
 	return cmd
+}
+
+func newAddEventTypeCommand(params *baseParams) *cobra.Command {
+	var name string
+	var colorName string
+	var customPropertyPairs []string
+	addCmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add an event type",
+		Run: func(cmd *cobra.Command, args []string) {
+			if name == "" {
+				dief("--name is required")
+			}
+			customProperties, err := parseEventTypeCustomProperties(customPropertyPairs)
+			if err != nil {
+				dief("Failed to add event type: %s", err)
+			}
+			client := api.NewRemoteFoxgloveClient(
+				params.baseURL, *params.clientID,
+				params.token,
+				params.userAgent,
+			)
+			resp, err := client.CreateEventType(api.CreateEventTypeRequest{
+				Name:             name,
+				ColorName:        colorName,
+				CustomProperties: customProperties,
+			})
+			if err != nil {
+				if err == api.ErrForbidden {
+					dief("Not authenticated. Run foxglove auth login.")
+				}
+				dief("Failed to add event type: %s", err)
+			}
+			fmt.Fprintf(os.Stderr, "Created event type: %s\n", resp.ID)
+		},
+	}
+	addCmd.PersistentFlags().StringVarP(&name, "name", "", "", "Name of the event type")
+	addCmd.PersistentFlags().StringVarP(&colorName, "color-name", "", "", "Color name of the event type, e.g. red")
+	addCmd.PersistentFlags().StringArrayVarP(&customPropertyPairs, "custom-property", "", []string{}, "Custom property ID, or ID:true/false for required. Multiple may be specified.")
+	return addCmd
+}
+
+func newGetEventTypeCommand(params *baseParams) *cobra.Command {
+	var format string
+	var isJsonFormat bool
+	getCmd := &cobra.Command{
+		Use:   "get [ID]",
+		Short: "Get an event type",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			client := api.NewRemoteFoxgloveClient(
+				params.baseURL, *params.clientID,
+				params.token,
+				params.userAgent,
+			)
+			eventType, err := client.GetEventType(args[0])
+			if err != nil {
+				if err == api.ErrForbidden {
+					dief("Not authenticated. Run foxglove auth login.")
+				}
+				if err == api.ErrNotFound {
+					dief("Event type not found: %s", args[0])
+				}
+				dief("Failed to get event type: %s", err)
+			}
+			format = ResolveFormat(format, isJsonFormat)
+			if err := renderRecord(os.Stdout, eventType, format); err != nil {
+				dief("Failed to get event type: %s", err)
+			}
+		},
+	}
+	AddFormatFlag(getCmd, &format)
+	AddJsonFlag(getCmd, &isJsonFormat)
+	return getCmd
+}
+
+func newEditEventTypeCommand(params *baseParams) *cobra.Command {
+	var name string
+	var colorName string
+	var customPropertyPairs []string
+	editCmd := &cobra.Command{
+		Use:   "edit [ID]",
+		Short: "Edit an event type",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			req := api.UpdateEventTypeRequest{}
+			if cmd.Flags().Changed("name") {
+				req.Name = name
+			}
+			if cmd.Flags().Changed("color-name") {
+				req.ColorName = colorName
+			}
+			if cmd.Flags().Changed("custom-property") {
+				customProperties, err := parseEventTypeCustomProperties(customPropertyPairs)
+				if err != nil {
+					dief("Failed to edit event type: %s", err)
+				}
+				req.CustomProperties = &customProperties
+			}
+			if req.Name == "" && req.ColorName == "" && req.CustomProperties == nil {
+				dief("Nothing to update")
+			}
+			client := api.NewRemoteFoxgloveClient(
+				params.baseURL, *params.clientID,
+				params.token,
+				params.userAgent,
+			)
+			resp, err := client.UpdateEventType(args[0], req)
+			if err != nil {
+				if err == api.ErrForbidden {
+					dief("Not authenticated. Run foxglove auth login.")
+				}
+				if err == api.ErrNotFound {
+					dief("Event type not found: %s", args[0])
+				}
+				dief("Failed to edit event type: %s", err)
+			}
+			fmt.Fprintf(os.Stderr, "Event type updated: %s\n", resp.ID)
+		},
+	}
+	editCmd.PersistentFlags().StringVarP(&name, "name", "", "", "Name of the event type")
+	editCmd.PersistentFlags().StringVarP(&colorName, "color-name", "", "", "Color name of the event type, e.g. red")
+	editCmd.PersistentFlags().StringArrayVarP(&customPropertyPairs, "custom-property", "", []string{}, "Custom property ID, or ID:true/false for required. Replaces the current list. Multiple may be specified.")
+	return editCmd
+}
+
+func newDeleteEventTypeCommand(params *baseParams) *cobra.Command {
+	deleteCmd := &cobra.Command{
+		Use:   "delete [ID]",
+		Short: "Delete an event type",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			client := api.NewRemoteFoxgloveClient(
+				params.baseURL, *params.clientID,
+				params.token,
+				params.userAgent,
+			)
+			if err := client.DeleteEventType(args[0]); err != nil {
+				if err == api.ErrForbidden {
+					dief("Not authenticated. Run foxglove auth login.")
+				}
+				dief("Failed to delete event type: %s", err)
+			}
+			fmt.Fprintf(os.Stderr, "Event type deleted: %s\n", args[0])
+		},
+	}
+	return deleteCmd
 }

--- a/foxglove/cmd/event_types.go
+++ b/foxglove/cmd/event_types.go
@@ -89,9 +89,6 @@ func newAddEventTypeCommand(params *baseParams) *cobra.Command {
 				CustomProperties: customProperties,
 			})
 			if err != nil {
-				if err == api.ErrForbidden {
-					dief("Not authenticated. Run foxglove auth login.")
-				}
 				dief("Failed to add event type: %s", err)
 			}
 			fmt.Fprintf(os.Stderr, "Created event type: %s\n", resp.ID)
@@ -118,12 +115,6 @@ func newGetEventTypeCommand(params *baseParams) *cobra.Command {
 			)
 			eventType, err := client.GetEventType(args[0])
 			if err != nil {
-				if err == api.ErrForbidden {
-					dief("Not authenticated. Run foxglove auth login.")
-				}
-				if err == api.ErrNotFound {
-					dief("Event type not found: %s", args[0])
-				}
 				dief("Failed to get event type: %s", err)
 			}
 			format = ResolveFormat(format, isJsonFormat)
@@ -132,6 +123,7 @@ func newGetEventTypeCommand(params *baseParams) *cobra.Command {
 			}
 		},
 	}
+	getCmd.InheritedFlags()
 	AddFormatFlag(getCmd, &format)
 	AddJsonFlag(getCmd, &isJsonFormat)
 	return getCmd
@@ -170,17 +162,12 @@ func newEditEventTypeCommand(params *baseParams) *cobra.Command {
 			)
 			resp, err := client.UpdateEventType(args[0], req)
 			if err != nil {
-				if err == api.ErrForbidden {
-					dief("Not authenticated. Run foxglove auth login.")
-				}
-				if err == api.ErrNotFound {
-					dief("Event type not found: %s", args[0])
-				}
 				dief("Failed to edit event type: %s", err)
 			}
 			fmt.Fprintf(os.Stderr, "Event type updated: %s\n", resp.ID)
 		},
 	}
+	editCmd.InheritedFlags()
 	editCmd.PersistentFlags().StringVarP(&name, "name", "", "", "Name of the event type")
 	editCmd.PersistentFlags().StringVarP(&colorName, "color-name", "", "", "Color name of the event type, e.g. red")
 	editCmd.PersistentFlags().StringArrayVarP(&customPropertyPairs, "custom-property", "", []string{}, "Custom property ID, or ID:true/false for required. Replaces the current list. Multiple may be specified.")
@@ -199,13 +186,11 @@ func newDeleteEventTypeCommand(params *baseParams) *cobra.Command {
 				params.userAgent,
 			)
 			if err := client.DeleteEventType(args[0]); err != nil {
-				if err == api.ErrForbidden {
-					dief("Not authenticated. Run foxglove auth login.")
-				}
 				dief("Failed to delete event type: %s", err)
 			}
 			fmt.Fprintf(os.Stderr, "Event type deleted: %s\n", args[0])
 		},
 	}
+	deleteCmd.InheritedFlags()
 	return deleteCmd
 }

--- a/foxglove/cmd/event_types_test.go
+++ b/foxglove/cmd/event_types_test.go
@@ -35,7 +35,7 @@ func TestEventTypesClient(t *testing.T) {
 	assert.NotEmpty(t, created.ID)
 	assert.Equal(t, "Hardware Fault", created.Name)
 	assert.Equal(t, "red", created.ColorName)
-	assert.Equal(t, []api.EventTypeCustomProperty{{ID: "cprop_evt_str", Required: true}}, created.CustomProperties)
+	assert.Equal(t, []api.EventTypeCustomProperty{{ID: "cprop_evt_str", Required: true}}, created.Properties)
 
 	got, err := client.GetEventType(created.ID)
 	require.NoError(t, err)
@@ -50,7 +50,7 @@ func TestEventTypesClient(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Fault", updated.Name)
 	assert.Equal(t, "orange", updated.ColorName)
-	assert.Equal(t, updatedProps, updated.CustomProperties)
+	assert.Equal(t, updatedProps, updated.Properties)
 
 	_, err = client.GetEventType("evtt_missing")
 	assert.ErrorIs(t, err, api.ErrNotFound)
@@ -89,8 +89,8 @@ func TestAddEventTypeCommandSendsPublicBody(t *testing.T) {
 	cmd.SetArgs([]string{
 		"--name", "Incident",
 		"--color-name", "red",
-		"--custom-property", "cprop_1:true",
-		"--custom-property", "cprop_2",
+		"--property", "cprop_1:true",
+		"--property", "cprop_2",
 	})
 	assert.NoError(t, cmd.Execute())
 }
@@ -125,7 +125,7 @@ func TestGetEditDeleteEventTypeCommands(t *testing.T) {
 	assert.NoError(t, getCmd.Execute())
 
 	editCmd := newEditEventTypeCommand(params)
-	editCmd.SetArgs([]string{"evtt_1", "--name", "Fault", "--color-name", "orange", "--custom-property", "cprop_1:true"})
+	editCmd.SetArgs([]string{"evtt_1", "--name", "Fault", "--color-name", "orange", "--property", "cprop_1:true"})
 	assert.NoError(t, editCmd.Execute())
 	assert.Equal(t, "Fault", patchBody.Name)
 	assert.Equal(t, "orange", patchBody.ColorName)
@@ -133,22 +133,22 @@ func TestGetEditDeleteEventTypeCommands(t *testing.T) {
 	assert.Equal(t, []api.EventTypeCustomProperty{{ID: "cprop_1", Required: true}}, *patchBody.CustomProperties)
 
 	clearCmd := newEditEventTypeCommand(params)
-	clearCmd.SetArgs([]string{"evtt_1", "--clear-custom-properties"})
+	clearCmd.SetArgs([]string{"evtt_1", "--clear-properties"})
 	assert.NoError(t, clearCmd.Execute())
 	require.NotNil(t, patchBody.CustomProperties)
 	assert.Empty(t, *patchBody.CustomProperties)
 
 	invalidPropertiesCmd := newEditEventTypeCommand(params)
-	invalidPropertiesCmd.SetArgs([]string{"evtt_1", "--custom-property", "cprop_1", "--clear-custom-properties"})
-	assert.EqualError(t, invalidPropertiesCmd.Execute(), "--custom-property and --clear-custom-properties cannot be used together")
+	invalidPropertiesCmd.SetArgs([]string{"evtt_1", "--property", "cprop_1", "--clear-properties"})
+	assert.EqualError(t, invalidPropertiesCmd.Execute(), "--property and --clear-properties cannot be used together")
 
 	deleteCmd := newDeleteEventTypeCommand(params)
 	deleteCmd.SetArgs([]string{"evtt_1"})
 	assert.NoError(t, deleteCmd.Execute())
 }
 
-func TestParseEventTypeCustomProperties(t *testing.T) {
-	props, err := parseEventTypeCustomProperties([]string{"cprop_1:true", "cprop_2:false", "cprop_3"})
+func TestParseEventTypeProperties(t *testing.T) {
+	props, err := parseEventTypeProperties([]string{"cprop_1:true", "cprop_2:false", "cprop_3"})
 	assert.NoError(t, err)
 	assert.Equal(t, []api.EventTypeCustomProperty{
 		{ID: "cprop_1", Required: true},
@@ -156,6 +156,6 @@ func TestParseEventTypeCustomProperties(t *testing.T) {
 		{ID: "cprop_3", Required: false},
 	}, props)
 
-	_, err = parseEventTypeCustomProperties([]string{"cprop_1:maybe"})
+	_, err = parseEventTypeProperties([]string{"cprop_1:maybe"})
 	assert.Error(t, err)
 }

--- a/foxglove/cmd/event_types_test.go
+++ b/foxglove/cmd/event_types_test.go
@@ -103,6 +103,7 @@ func TestGetEditDeleteEventTypeCommands(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/event-types/evtt_1":
 			_, _ = w.Write([]byte(`{"id":"evtt_1","name":"Incident","colorName":"red","customProperties":[],"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}`))
 		case r.Method == http.MethodPatch && r.URL.Path == "/v1/event-types/evtt_1":
+			patchBody = api.UpdateEventTypeRequest{}
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&patchBody))
 			_, _ = w.Write([]byte(`{"id":"evtt_1","name":"Fault","colorName":"orange","customProperties":[{"id":"cprop_1","required":true}],"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}`))
 		case r.Method == http.MethodDelete && r.URL.Path == "/v1/event-types/evtt_1":
@@ -130,6 +131,16 @@ func TestGetEditDeleteEventTypeCommands(t *testing.T) {
 	assert.Equal(t, "orange", patchBody.ColorName)
 	require.NotNil(t, patchBody.CustomProperties)
 	assert.Equal(t, []api.EventTypeCustomProperty{{ID: "cprop_1", Required: true}}, *patchBody.CustomProperties)
+
+	clearCmd := newEditEventTypeCommand(params)
+	clearCmd.SetArgs([]string{"evtt_1", "--clear-custom-properties"})
+	assert.NoError(t, clearCmd.Execute())
+	require.NotNil(t, patchBody.CustomProperties)
+	assert.Empty(t, *patchBody.CustomProperties)
+
+	invalidPropertiesCmd := newEditEventTypeCommand(params)
+	invalidPropertiesCmd.SetArgs([]string{"evtt_1", "--custom-property", "cprop_1", "--clear-custom-properties"})
+	assert.EqualError(t, invalidPropertiesCmd.Execute(), "--custom-property and --clear-custom-properties cannot be used together")
 
 	deleteCmd := newDeleteEventTypeCommand(params)
 	deleteCmd.SetArgs([]string{"evtt_1"})

--- a/foxglove/cmd/event_types_test.go
+++ b/foxglove/cmd/event_types_test.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/foxglove/foxglove-cli/foxglove/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventTypesClient(t *testing.T) {
+	ctx := context.Background()
+	sv, err := api.NewMockServer(ctx)
+	require.NoError(t, err)
+	client := api.NewMockAuthedClient(t, sv.BaseURL())
+
+	listed, err := client.EventTypes(&api.EventTypesRequest{})
+	require.NoError(t, err)
+	require.NotEmpty(t, listed)
+	assert.Equal(t, "evtt_default", listed[0].ID)
+
+	created, err := client.CreateEventType(api.CreateEventTypeRequest{
+		Name:      "Hardware Fault",
+		ColorName: "red",
+		CustomProperties: []api.EventTypeCustomProperty{
+			{ID: "cprop_evt_str", Required: true},
+		},
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, created.ID)
+	assert.Equal(t, "Hardware Fault", created.Name)
+	assert.Equal(t, "red", created.ColorName)
+	assert.Equal(t, []api.EventTypeCustomProperty{{ID: "cprop_evt_str", Required: true}}, created.CustomProperties)
+
+	got, err := client.GetEventType(created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, got.ID)
+
+	updatedProps := []api.EventTypeCustomProperty{{ID: "cprop_evt_enum", Required: false}}
+	updated, err := client.UpdateEventType(created.ID, api.UpdateEventTypeRequest{
+		Name:             "Fault",
+		ColorName:        "orange",
+		CustomProperties: &updatedProps,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Fault", updated.Name)
+	assert.Equal(t, "orange", updated.ColorName)
+	assert.Equal(t, updatedProps, updated.CustomProperties)
+
+	_, err = client.GetEventType("evtt_missing")
+	assert.ErrorIs(t, err, api.ErrNotFound)
+
+	err = client.DeleteEventType(created.ID)
+	require.NoError(t, err)
+	_, err = client.GetEventType(created.ID)
+	assert.ErrorIs(t, err, api.ErrNotFound)
+}
+
+func TestAddEventTypeCommandSendsPublicBody(t *testing.T) {
+	clientID := "custom-client"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/v1/event-types", r.URL.Path)
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var req api.CreateEventTypeRequest
+		require.NoError(t, json.Unmarshal(body, &req))
+		assert.Equal(t, "Incident", req.Name)
+		assert.Equal(t, "red", req.ColorName)
+		assert.Equal(t, []api.EventTypeCustomProperty{
+			{ID: "cprop_1", Required: true},
+			{ID: "cprop_2", Required: false},
+		}, req.CustomProperties)
+		_, _ = w.Write([]byte(`{"id":"evtt_1","name":"Incident","colorName":"red","customProperties":[],"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}`))
+	}))
+	defer server.Close()
+
+	cmd := newAddEventTypeCommand(&baseParams{
+		baseURL:   server.URL,
+		clientID:  &clientID,
+		token:     "custom-token",
+		userAgent: "foxglove-cli/test-version",
+	})
+	cmd.SetArgs([]string{
+		"--name", "Incident",
+		"--color-name", "red",
+		"--custom-property", "cprop_1:true",
+		"--custom-property", "cprop_2",
+	})
+	assert.NoError(t, cmd.Execute())
+}
+
+func TestGetEditDeleteEventTypeCommands(t *testing.T) {
+	clientID := "custom-client"
+	var patchBody api.UpdateEventTypeRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/event-types/evtt_1":
+			_, _ = w.Write([]byte(`{"id":"evtt_1","name":"Incident","colorName":"red","customProperties":[],"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}`))
+		case r.Method == http.MethodPatch && r.URL.Path == "/v1/event-types/evtt_1":
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&patchBody))
+			_, _ = w.Write([]byte(`{"id":"evtt_1","name":"Fault","colorName":"orange","customProperties":[{"id":"cprop_1","required":true}],"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}`))
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/event-types/evtt_1":
+			_, _ = w.Write([]byte(`{"id":"evtt_1"}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	params := &baseParams{
+		baseURL:   server.URL,
+		clientID:  &clientID,
+		token:     "custom-token",
+		userAgent: "foxglove-cli/test-version",
+	}
+
+	getCmd := newGetEventTypeCommand(params)
+	getCmd.SetArgs([]string{"evtt_1", "--format", "json"})
+	assert.NoError(t, getCmd.Execute())
+
+	editCmd := newEditEventTypeCommand(params)
+	editCmd.SetArgs([]string{"evtt_1", "--name", "Fault", "--color-name", "orange", "--custom-property", "cprop_1:true"})
+	assert.NoError(t, editCmd.Execute())
+	assert.Equal(t, "Fault", patchBody.Name)
+	assert.Equal(t, "orange", patchBody.ColorName)
+	require.NotNil(t, patchBody.CustomProperties)
+	assert.Equal(t, []api.EventTypeCustomProperty{{ID: "cprop_1", Required: true}}, *patchBody.CustomProperties)
+
+	deleteCmd := newDeleteEventTypeCommand(params)
+	deleteCmd.SetArgs([]string{"evtt_1"})
+	assert.NoError(t, deleteCmd.Execute())
+}
+
+func TestParseEventTypeCustomProperties(t *testing.T) {
+	props, err := parseEventTypeCustomProperties([]string{"cprop_1:true", "cprop_2:false", "cprop_3"})
+	assert.NoError(t, err)
+	assert.Equal(t, []api.EventTypeCustomProperty{
+		{ID: "cprop_1", Required: true},
+		{ID: "cprop_2", Required: false},
+		{ID: "cprop_3", Required: false},
+	}, props)
+
+	_, err = parseEventTypeCustomProperties([]string{"cprop_1:maybe"})
+	assert.Error(t, err)
+}

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -23,6 +23,30 @@ func parseMetadataPairs(keyvals []string) (map[string]string, error) {
 	return metadata, nil
 }
 
+func parseEventProperties(
+	client *api.FoxgloveClient,
+	propertyPairs []string,
+	removeKeys []string,
+) (map[string]interface{}, error) {
+	properties, err := util.EventProperties(propertyPairs, client)
+	if err != nil {
+		return nil, err
+	}
+	if len(removeKeys) == 0 {
+		return properties, nil
+	}
+	if properties == nil {
+		properties = make(map[string]interface{})
+	}
+	for _, key := range removeKeys {
+		if key == "" {
+			return nil, fmt.Errorf("custom property key to remove cannot be empty")
+		}
+		properties[key] = nil
+	}
+	return properties, nil
+}
+
 func joinQueryFields(queryFields []string) (string, error) {
 	for _, qf := range queryFields {
 		if qf != "metadata" && qf != "properties" {
@@ -30,6 +54,16 @@ func joinQueryFields(queryFields []string) (string, error) {
 		}
 	}
 	return strings.Join(queryFields, ","), nil
+}
+
+func validateCreateEventData(eventTypeID string, metadataPairs, propertyPairs []string) error {
+	if eventTypeID != "" && len(metadataPairs) > 0 {
+		return fmt.Errorf("--metadata cannot be used with --event-type-id")
+	}
+	if eventTypeID == "" && len(propertyPairs) > 0 {
+		return fmt.Errorf("--event-type-id is required when using --property")
+	}
+	return nil
 }
 
 func newAddEventCommand(params *baseParams) *cobra.Command {
@@ -45,6 +79,9 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 		Use:   "add",
 		Short: "Add an event",
 		Run: func(cmd *cobra.Command, args []string) {
+			if err := validateCreateEventData(eventTypeID, keyvals, propertyPairs); err != nil {
+				dief("Failed to add event: %s", err)
+			}
 			client := api.NewRemoteFoxgloveClient(
 				params.baseURL, *params.clientID,
 				params.token,
@@ -230,10 +267,18 @@ func newEditEventCommand(params *baseParams) *cobra.Command {
 	var keyvals []string
 	var eventTypeID string
 	var propertyPairs []string
+	var removeProperties []string
+	var clearMetadata bool
 	editEventCmd := &cobra.Command{
 		Use:   "edit [ID]",
 		Short: "Edit an event",
 		Args:  cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("metadata") && clearMetadata {
+				return fmt.Errorf("--metadata and --clear-metadata cannot be used together")
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			client := api.NewRemoteFoxgloveClient(
 				params.baseURL, *params.clientID,
@@ -261,13 +306,17 @@ func newEditEventCommand(params *baseParams) *cobra.Command {
 				if err != nil {
 					dief("Failed to edit event: %s", err)
 				}
-				req.Metadata = metadata
+				req.Metadata = &metadata
+			}
+			if clearMetadata {
+				metadata := map[string]string{}
+				req.Metadata = &metadata
 			}
 			if cmd.Flags().Changed("event-type-id") {
 				req.EventTypeID = &eventTypeID
 			}
-			if cmd.Flags().Changed("property") {
-				properties, err := util.EventProperties(propertyPairs, client)
+			if cmd.Flags().Changed("property") || cmd.Flags().Changed("remove-property") {
+				properties, err := parseEventProperties(client, propertyPairs, removeProperties)
 				if err != nil {
 					dief("Failed to edit event: %s", err)
 				}
@@ -288,8 +337,10 @@ func newEditEventCommand(params *baseParams) *cobra.Command {
 	editEventCmd.PersistentFlags().StringVarP(&start, "start", "", "", "Event start time (inclusive), RFC 3339 or ISO 8601 format")
 	editEventCmd.PersistentFlags().StringVarP(&end, "end", "", "", "Event end time (inclusive), RFC 3339 or ISO 8601 format")
 	editEventCmd.PersistentFlags().StringArrayVarP(&keyvals, "metadata", "m", []string{}, "Replace all event metadata with these colon-separated key value pairs. Multiple may be specified.")
+	editEventCmd.PersistentFlags().BoolVarP(&clearMetadata, "clear-metadata", "", false, "Remove all event metadata.")
 	editEventCmd.PersistentFlags().StringVarP(&eventTypeID, "event-type-id", "", "", "Event type ID. Pass an empty value to remove the event type.")
 	editEventCmd.PersistentFlags().StringArrayVarP(&propertyPairs, "property", "p", []string{}, "Set these event custom property keys. Other keys stay unchanged. Multiple may be specified.")
+	editEventCmd.PersistentFlags().StringArrayVarP(&removeProperties, "remove-property", "", []string{}, "Remove these event custom property keys. Multiple may be specified.")
 	return editEventCmd
 }
 

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -3,18 +3,65 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/foxglove/foxglove-cli/foxglove/api"
 	"github.com/foxglove/foxglove-cli/foxglove/util"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
+
+func parseMetadataPairs(keyvals []string) (map[string]string, error) {
+	metadata := make(map[string]string)
+	for _, kv := range keyvals {
+		key, val, err := util.SplitPair(kv, ':')
+		if err != nil {
+			return nil, fmt.Errorf("invalid metadata key/value pair: %s", kv)
+		}
+		metadata[key] = val
+	}
+	return metadata, nil
+}
+
+func parseEventProperties(
+	client *api.FoxgloveClient,
+	propertyPairs []string,
+	unsetKeys []string,
+) (map[string]interface{}, error) {
+	properties, err := util.EventProperties(propertyPairs, client)
+	if err != nil {
+		return nil, err
+	}
+	if len(unsetKeys) == 0 {
+		return properties, nil
+	}
+	if properties == nil {
+		properties = make(map[string]interface{})
+	}
+	for _, key := range unsetKeys {
+		properties[key] = nil
+	}
+	return properties, nil
+}
+
+func joinQueryFields(queryFields []string) (string, error) {
+	for _, qf := range queryFields {
+		if qf != "metadata" && qf != "properties" {
+			return "", fmt.Errorf("invalid --query-field value %q: must be \"metadata\" or \"properties\"", qf)
+		}
+	}
+	return strings.Join(queryFields, ","), nil
+}
 
 func newAddEventCommand(params *baseParams) *cobra.Command {
 	var deviceID string
+	var deviceName string
+	var projectID string
 	var start string
 	var end string
 	var keyvals []string
 	var eventTypeID string
+	var propertyPairs []string
 	addEventCmd := &cobra.Command{
 		Use:   "add",
 		Short: "Add an event",
@@ -25,22 +72,34 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 				params.userAgent,
 			)
 
-			metadata := make(map[string]string)
-			for _, kv := range keyvals {
-				key, val, err := util.SplitPair(kv, ':')
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "Invalid metadata key/value pair: %s\n", kv)
-					os.Exit(1)
-				}
-				metadata[key] = val
+			metadata, err := parseMetadataPairs(keyvals)
+			if err != nil {
+				dief("Failed to add event: %s", err)
+			}
+
+			properties, err := parseEventProperties(client, propertyPairs, nil)
+			if err != nil {
+				dief("Failed to add event: %s", err)
+			}
+
+			startTime, err := maybeConvertToRFC3339(start)
+			if err != nil {
+				dief("failed to parse start time: %s", err)
+			}
+			endTime, err := maybeConvertToRFC3339(end)
+			if err != nil {
+				dief("failed to parse end time: %s", err)
 			}
 
 			response, err := client.CreateEvent(api.CreateEventRequest{
 				DeviceID:    deviceID,
-				Start:       start,
-				End:         end,
+				DeviceName:  deviceName,
+				ProjectID:   projectID,
+				Start:       startTime,
+				End:         endTime,
 				Metadata:    metadata,
 				EventTypeID: eventTypeID,
+				Properties:  properties,
 			})
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to add event: %s\n", err)
@@ -50,10 +109,14 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 		},
 	}
 	addEventCmd.PersistentFlags().StringVarP(&deviceID, "device-id", "", "", "Device ID")
-	addEventCmd.PersistentFlags().StringVarP(&start, "start", "", "", "Start of event, RFC 3339 date-time format")
-	addEventCmd.PersistentFlags().StringVarP(&end, "end", "", "", "End of event (inclusive), RFC 3339 date-time format")
+	addEventCmd.PersistentFlags().StringVarP(&deviceName, "device-name", "", "", "Device name")
+	addEventCmd.PersistentFlags().StringVarP(&projectID, "project-id", "", viper.GetString("default_project_id"), "Project ID used to disambiguate device-id and device-name")
+	addEventCmd.PersistentFlags().StringVarP(&start, "start", "", "", "Start of event (inclusive), RFC 3339 or ISO 8601 format")
+	addEventCmd.PersistentFlags().StringVarP(&end, "end", "", "", "End of event (inclusive), RFC 3339 or ISO 8601 format")
 	addEventCmd.PersistentFlags().StringArrayVarP(&keyvals, "metadata", "m", []string{}, "Metadata colon-separated key value pair. Multiple may be specified.")
 	addEventCmd.PersistentFlags().StringVarP(&eventTypeID, "event-type-id", "", "", "Event type ID to associate with this event (e.g. evtt_123)")
+	addEventCmd.PersistentFlags().StringArrayVarP(&propertyPairs, "property", "p", []string{}, "Event custom property colon-separated key value pair. Multiple may be specified.")
+	AddDeviceAutocompletion(addEventCmd, params)
 	return addEventCmd
 }
 
@@ -61,13 +124,17 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 	var format string
 	var deviceID string
 	var deviceName string
+	var projectID string
 	var sortBy string
 	var sortOrder string
 	var limit int
 	var offset int
 	var start string
 	var end string
+	var createdAfter string
+	var updatedAfter string
 	var query string
+	var eventID string
 	var eventTypeID string
 	var queryFields []string
 	var isJsonFormat bool
@@ -75,31 +142,50 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 		Use:   "list",
 		Short: "List events",
 		Run: func(cmd *cobra.Command, args []string) {
-			for _, qf := range queryFields {
-				if qf != "metadata" && qf != "properties" {
-					dief("Invalid --query-field value %q: must be \"metadata\" or \"properties\"", qf)
-				}
+			queryFieldsValue, err := joinQueryFields(queryFields)
+			if err != nil {
+				dief("%s", err)
 			}
 			client := api.NewRemoteFoxgloveClient(
 				params.baseURL, *params.clientID,
 				params.token,
 				params.userAgent,
 			)
+			startTime, err := maybeConvertToRFC3339(start)
+			if err != nil {
+				dief("failed to parse start time: %s", err)
+			}
+			endTime, err := maybeConvertToRFC3339(end)
+			if err != nil {
+				dief("failed to parse end time: %s", err)
+			}
+			createdAfterTime, err := maybeConvertToRFC3339(createdAfter)
+			if err != nil {
+				dief("failed to parse created-after time: %s", err)
+			}
+			updatedAfterTime, err := maybeConvertToRFC3339(updatedAfter)
+			if err != nil {
+				dief("failed to parse updated-after time: %s", err)
+			}
 			format = ResolveFormat(format, isJsonFormat)
-			err := renderList(
+			err = renderList(
 				os.Stdout,
 				&api.EventsRequest{
-					DeviceID:    deviceID,
-					DeviceName:  deviceName,
-					SortBy:      sortBy,
-					SortOrder:   sortOrder,
-					Limit:       limit,
-					Offset:      offset,
-					Start:       start,
-					End:         end,
-					Query:       query,
-					EventTypeID: eventTypeID,
-					QueryFields: queryFields,
+					CreatedAfter: createdAfterTime,
+					DeviceID:     deviceID,
+					DeviceName:   deviceName,
+					End:          endTime,
+					EventID:      eventID,
+					EventTypeID:  eventTypeID,
+					Limit:        limit,
+					Offset:       offset,
+					ProjectID:    projectID,
+					Query:        query,
+					QueryFields:  queryFieldsValue,
+					SortBy:       sortBy,
+					SortOrder:    sortOrder,
+					Start:        startTime,
+					UpdatedAfter: updatedAfterTime,
 				},
 				client.Events,
 				format,
@@ -112,12 +198,16 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 	eventsListCmd.InheritedFlags()
 	eventsListCmd.PersistentFlags().StringVarP(&deviceID, "device-id", "", "", "Device ID")
 	eventsListCmd.PersistentFlags().StringVarP(&deviceName, "device-name", "", "", "Device name")
-	eventsListCmd.PersistentFlags().StringVarP(&sortBy, "sort-by", "", "", "name of sort column")
+	eventsListCmd.PersistentFlags().StringVarP(&projectID, "project-id", "", viper.GetString("default_project_id"), "Project ID")
+	eventsListCmd.PersistentFlags().StringVarP(&eventID, "event-id", "", "", "Filter by exact event ID")
+	eventsListCmd.PersistentFlags().StringVarP(&sortBy, "sort-by", "", "", "Field to sort by (id, deviceId, deviceName, start, createdAt, updatedAt)")
 	eventsListCmd.PersistentFlags().StringVarP(&sortOrder, "sort-order", "", "asc", "sort order")
 	eventsListCmd.PersistentFlags().IntVarP(&limit, "limit", "", 100, "limit")
 	eventsListCmd.PersistentFlags().IntVarP(&offset, "offset", "", 0, "offset")
-	eventsListCmd.PersistentFlags().StringVarP(&start, "start", "", "", "Exclude events before this time, RFC 3339 or ISO 8601 format")
-	eventsListCmd.PersistentFlags().StringVarP(&end, "end", "", "", "Exclude events after this time, RFC 3339 or ISO 8601 format")
+	eventsListCmd.PersistentFlags().StringVarP(&start, "start", "", "", "Exclude events that do not intersect this start time, RFC 3339 or ISO 8601 format")
+	eventsListCmd.PersistentFlags().StringVarP(&end, "end", "", "", "Exclude events that do not intersect this end time, RFC 3339 or ISO 8601 format")
+	eventsListCmd.PersistentFlags().StringVarP(&createdAfter, "created-after", "", "", "Return events created after this time, RFC 3339 or ISO 8601 format")
+	eventsListCmd.PersistentFlags().StringVarP(&updatedAfter, "updated-after", "", "", "Return events updated after this time, RFC 3339 or ISO 8601 format")
 	eventsListCmd.PersistentFlags().StringVarP(&query, "query", "", "", "Filter by properties or metadata, e.g. \"$key:$value\". See API docs for query syntax.")
 	eventsListCmd.PersistentFlags().StringVarP(&eventTypeID, "event-type-id", "", "", "Filter by event type ID (e.g. evtt_123)")
 	eventsListCmd.PersistentFlags().StringArrayVarP(&queryFields, "query-field", "", []string{}, "Fields to query by (\"metadata\" or \"properties\"). Multiple may be specified. Defaults to \"metadata\".")
@@ -125,4 +215,137 @@ func newListEventsCommand(params *baseParams) *cobra.Command {
 	AddFormatFlag(eventsListCmd, &format)
 	AddJsonFlag(eventsListCmd, &isJsonFormat)
 	return eventsListCmd
+}
+
+func newGetEventCommand(params *baseParams) *cobra.Command {
+	var format string
+	var isJsonFormat bool
+	getEventCmd := &cobra.Command{
+		Use:   "get [ID]",
+		Short: "Get an event",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			client := api.NewRemoteFoxgloveClient(
+				params.baseURL, *params.clientID,
+				params.token,
+				params.userAgent,
+			)
+			event, err := client.GetEvent(args[0])
+			if err != nil {
+				if err == api.ErrForbidden {
+					dief("Not authenticated. Run foxglove auth login.")
+				}
+				if err == api.ErrNotFound {
+					dief("Event not found: %s", args[0])
+				}
+				dief("Failed to get event: %s", err)
+			}
+			format = ResolveFormat(format, isJsonFormat)
+			if err := renderRecord(os.Stdout, event, format); err != nil {
+				dief("Failed to get event: %s", err)
+			}
+		},
+	}
+	AddFormatFlag(getEventCmd, &format)
+	AddJsonFlag(getEventCmd, &isJsonFormat)
+	return getEventCmd
+}
+
+func newEditEventCommand(params *baseParams) *cobra.Command {
+	var start string
+	var end string
+	var keyvals []string
+	var eventTypeID string
+	var propertyPairs []string
+	var unsetProperties []string
+	editEventCmd := &cobra.Command{
+		Use:   "edit [ID]",
+		Short: "Edit an event",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			client := api.NewRemoteFoxgloveClient(
+				params.baseURL, *params.clientID,
+				params.token,
+				params.userAgent,
+			)
+
+			req := api.UpdateEventRequest{}
+			if cmd.Flags().Changed("start") {
+				startTime, err := maybeConvertToRFC3339(start)
+				if err != nil {
+					dief("failed to parse start time: %s", err)
+				}
+				req.Start = startTime
+			}
+			if cmd.Flags().Changed("end") {
+				endTime, err := maybeConvertToRFC3339(end)
+				if err != nil {
+					dief("failed to parse end time: %s", err)
+				}
+				req.End = endTime
+			}
+			if cmd.Flags().Changed("metadata") {
+				metadata, err := parseMetadataPairs(keyvals)
+				if err != nil {
+					dief("Failed to edit event: %s", err)
+				}
+				req.Metadata = metadata
+			}
+			if cmd.Flags().Changed("event-type-id") {
+				req.EventTypeID = &eventTypeID
+			}
+			if cmd.Flags().Changed("property") || cmd.Flags().Changed("unset-property") {
+				properties, err := parseEventProperties(client, propertyPairs, unsetProperties)
+				if err != nil {
+					dief("Failed to edit event: %s", err)
+				}
+				req.Properties = properties
+			}
+			if req.Start == "" && req.End == "" && req.Metadata == nil && req.Properties == nil && req.EventTypeID == nil {
+				dief("Nothing to update")
+			}
+
+			resp, err := client.UpdateEvent(args[0], req)
+			if err != nil {
+				if err == api.ErrForbidden {
+					dief("Not authenticated. Run foxglove auth login.")
+				}
+				if err == api.ErrNotFound {
+					dief("Event not found: %s", args[0])
+				}
+				dief("Failed to edit event: %s", err)
+			}
+			fmt.Fprintf(os.Stderr, "Event updated: %s\n", resp.ID)
+		},
+	}
+	editEventCmd.PersistentFlags().StringVarP(&start, "start", "", "", "Event start time (inclusive), RFC 3339 or ISO 8601 format")
+	editEventCmd.PersistentFlags().StringVarP(&end, "end", "", "", "Event end time (inclusive), RFC 3339 or ISO 8601 format")
+	editEventCmd.PersistentFlags().StringArrayVarP(&keyvals, "metadata", "m", []string{}, "Metadata colon-separated key value pair. Multiple may be specified.")
+	editEventCmd.PersistentFlags().StringVarP(&eventTypeID, "event-type-id", "", "", "Event type ID. Pass an empty value to remove the event type.")
+	editEventCmd.PersistentFlags().StringArrayVarP(&propertyPairs, "property", "p", []string{}, "Event custom property colon-separated key value pair. Multiple may be specified.")
+	editEventCmd.PersistentFlags().StringArrayVarP(&unsetProperties, "unset-property", "", []string{}, "Event custom property key to unset. Multiple may be specified.")
+	return editEventCmd
+}
+
+func newDeleteEventCommand(params *baseParams) *cobra.Command {
+	deleteEventCmd := &cobra.Command{
+		Use:   "delete [ID]",
+		Short: "Delete an event",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			client := api.NewRemoteFoxgloveClient(
+				params.baseURL, *params.clientID,
+				params.token,
+				params.userAgent,
+			)
+			if err := client.DeleteEvent(args[0]); err != nil {
+				if err == api.ErrForbidden {
+					dief("Not authenticated. Run foxglove auth login.")
+				}
+				dief("Failed to delete event: %s", err)
+			}
+			fmt.Fprintf(os.Stderr, "Event deleted: %s\n", args[0])
+		},
+	}
+	return deleteEventCmd
 }

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -47,6 +47,9 @@ func parseEventProperties(
 	return properties, nil
 }
 
+// joinQueryFields encodes --query-field values as the public queryFields
+// parameter. The API uses OpenAPI explode: false (comma-joined), not repeated
+// queryFields= params.
 func joinQueryFields(queryFields []string) (string, error) {
 	for _, qf := range queryFields {
 		if qf != "metadata" && qf != "properties" {

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -23,27 +23,6 @@ func parseMetadataPairs(keyvals []string) (map[string]string, error) {
 	return metadata, nil
 }
 
-func parseEventProperties(
-	client *api.FoxgloveClient,
-	propertyPairs []string,
-	unsetKeys []string,
-) (map[string]interface{}, error) {
-	properties, err := util.EventProperties(propertyPairs, client)
-	if err != nil {
-		return nil, err
-	}
-	if len(unsetKeys) == 0 {
-		return properties, nil
-	}
-	if properties == nil {
-		properties = make(map[string]interface{})
-	}
-	for _, key := range unsetKeys {
-		properties[key] = nil
-	}
-	return properties, nil
-}
-
 func joinQueryFields(queryFields []string) (string, error) {
 	for _, qf := range queryFields {
 		if qf != "metadata" && qf != "properties" {
@@ -77,7 +56,7 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 				dief("Failed to add event: %s", err)
 			}
 
-			properties, err := parseEventProperties(client, propertyPairs, nil)
+			properties, err := util.EventProperties(propertyPairs, client)
 			if err != nil {
 				dief("Failed to add event: %s", err)
 			}
@@ -102,8 +81,7 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 				Properties:  properties,
 			})
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to add event: %s\n", err)
-				os.Exit(1)
+				dief("Failed to add event: %s", err)
 			}
 			fmt.Fprintf(os.Stderr, "Created event: %s\n", response.ID)
 		},
@@ -232,12 +210,6 @@ func newGetEventCommand(params *baseParams) *cobra.Command {
 			)
 			event, err := client.GetEvent(args[0])
 			if err != nil {
-				if err == api.ErrForbidden {
-					dief("Not authenticated. Run foxglove auth login.")
-				}
-				if err == api.ErrNotFound {
-					dief("Event not found: %s", args[0])
-				}
 				dief("Failed to get event: %s", err)
 			}
 			format = ResolveFormat(format, isJsonFormat)
@@ -246,6 +218,7 @@ func newGetEventCommand(params *baseParams) *cobra.Command {
 			}
 		},
 	}
+	getEventCmd.InheritedFlags()
 	AddFormatFlag(getEventCmd, &format)
 	AddJsonFlag(getEventCmd, &isJsonFormat)
 	return getEventCmd
@@ -257,7 +230,6 @@ func newEditEventCommand(params *baseParams) *cobra.Command {
 	var keyvals []string
 	var eventTypeID string
 	var propertyPairs []string
-	var unsetProperties []string
 	editEventCmd := &cobra.Command{
 		Use:   "edit [ID]",
 		Short: "Edit an event",
@@ -294,8 +266,8 @@ func newEditEventCommand(params *baseParams) *cobra.Command {
 			if cmd.Flags().Changed("event-type-id") {
 				req.EventTypeID = &eventTypeID
 			}
-			if cmd.Flags().Changed("property") || cmd.Flags().Changed("unset-property") {
-				properties, err := parseEventProperties(client, propertyPairs, unsetProperties)
+			if cmd.Flags().Changed("property") {
+				properties, err := util.EventProperties(propertyPairs, client)
 				if err != nil {
 					dief("Failed to edit event: %s", err)
 				}
@@ -307,23 +279,17 @@ func newEditEventCommand(params *baseParams) *cobra.Command {
 
 			resp, err := client.UpdateEvent(args[0], req)
 			if err != nil {
-				if err == api.ErrForbidden {
-					dief("Not authenticated. Run foxglove auth login.")
-				}
-				if err == api.ErrNotFound {
-					dief("Event not found: %s", args[0])
-				}
 				dief("Failed to edit event: %s", err)
 			}
 			fmt.Fprintf(os.Stderr, "Event updated: %s\n", resp.ID)
 		},
 	}
+	editEventCmd.InheritedFlags()
 	editEventCmd.PersistentFlags().StringVarP(&start, "start", "", "", "Event start time (inclusive), RFC 3339 or ISO 8601 format")
 	editEventCmd.PersistentFlags().StringVarP(&end, "end", "", "", "Event end time (inclusive), RFC 3339 or ISO 8601 format")
-	editEventCmd.PersistentFlags().StringArrayVarP(&keyvals, "metadata", "m", []string{}, "Metadata colon-separated key value pair. Multiple may be specified.")
+	editEventCmd.PersistentFlags().StringArrayVarP(&keyvals, "metadata", "m", []string{}, "Replace all event metadata with these colon-separated key value pairs. Multiple may be specified.")
 	editEventCmd.PersistentFlags().StringVarP(&eventTypeID, "event-type-id", "", "", "Event type ID. Pass an empty value to remove the event type.")
-	editEventCmd.PersistentFlags().StringArrayVarP(&propertyPairs, "property", "p", []string{}, "Event custom property colon-separated key value pair. Multiple may be specified.")
-	editEventCmd.PersistentFlags().StringArrayVarP(&unsetProperties, "unset-property", "", []string{}, "Event custom property key to unset. Multiple may be specified.")
+	editEventCmd.PersistentFlags().StringArrayVarP(&propertyPairs, "property", "p", []string{}, "Set these event custom property keys. Other keys stay unchanged. Multiple may be specified.")
 	return editEventCmd
 }
 
@@ -339,13 +305,11 @@ func newDeleteEventCommand(params *baseParams) *cobra.Command {
 				params.userAgent,
 			)
 			if err := client.DeleteEvent(args[0]); err != nil {
-				if err == api.ErrForbidden {
-					dief("Not authenticated. Run foxglove auth login.")
-				}
 				dief("Failed to delete event: %s", err)
 			}
 			fmt.Fprintf(os.Stderr, "Event deleted: %s\n", args[0])
 		},
 	}
+	deleteEventCmd.InheritedFlags()
 	return deleteEventCmd
 }

--- a/foxglove/cmd/events.go
+++ b/foxglove/cmd/events.go
@@ -40,7 +40,7 @@ func parseEventProperties(
 	}
 	for _, key := range removeKeys {
 		if key == "" {
-			return nil, fmt.Errorf("custom property key to remove cannot be empty")
+			return nil, fmt.Errorf("property key to remove cannot be empty")
 		}
 		properties[key] = nil
 	}
@@ -60,8 +60,8 @@ func validateCreateEventData(eventTypeID string, metadataPairs, propertyPairs []
 	if eventTypeID != "" && len(metadataPairs) > 0 {
 		return fmt.Errorf("--metadata cannot be used with --event-type-id")
 	}
-	if eventTypeID == "" && len(propertyPairs) > 0 {
-		return fmt.Errorf("--event-type-id is required when using --property")
+	if len(metadataPairs) > 0 && len(propertyPairs) > 0 {
+		return fmt.Errorf("--metadata cannot be used with --property")
 	}
 	return nil
 }
@@ -130,7 +130,7 @@ func newAddEventCommand(params *baseParams) *cobra.Command {
 	addEventCmd.PersistentFlags().StringVarP(&end, "end", "", "", "End of event (inclusive), RFC 3339 or ISO 8601 format")
 	addEventCmd.PersistentFlags().StringArrayVarP(&keyvals, "metadata", "m", []string{}, "Metadata colon-separated key value pair. Multiple may be specified.")
 	addEventCmd.PersistentFlags().StringVarP(&eventTypeID, "event-type-id", "", "", "Event type ID to associate with this event (e.g. evtt_123)")
-	addEventCmd.PersistentFlags().StringArrayVarP(&propertyPairs, "property", "p", []string{}, "Event custom property colon-separated key value pair. Multiple may be specified.")
+	addEventCmd.PersistentFlags().StringArrayVarP(&propertyPairs, "property", "p", []string{}, "Event property colon-separated key value pair. Multiple may be specified.")
 	AddDeviceAutocompletion(addEventCmd, params)
 	return addEventCmd
 }
@@ -339,8 +339,8 @@ func newEditEventCommand(params *baseParams) *cobra.Command {
 	editEventCmd.PersistentFlags().StringArrayVarP(&keyvals, "metadata", "m", []string{}, "Replace all event metadata with these colon-separated key value pairs. Multiple may be specified.")
 	editEventCmd.PersistentFlags().BoolVarP(&clearMetadata, "clear-metadata", "", false, "Remove all event metadata.")
 	editEventCmd.PersistentFlags().StringVarP(&eventTypeID, "event-type-id", "", "", "Event type ID. Pass an empty value to remove the event type.")
-	editEventCmd.PersistentFlags().StringArrayVarP(&propertyPairs, "property", "p", []string{}, "Set these event custom property keys. Other keys stay unchanged. Multiple may be specified.")
-	editEventCmd.PersistentFlags().StringArrayVarP(&removeProperties, "remove-property", "", []string{}, "Remove these event custom property keys. Multiple may be specified.")
+	editEventCmd.PersistentFlags().StringArrayVarP(&propertyPairs, "property", "p", []string{}, "Set these event property keys. Other keys stay unchanged. Multiple may be specified.")
+	editEventCmd.PersistentFlags().StringArrayVarP(&removeProperties, "remove-property", "", []string{}, "Remove these event property keys. Multiple may be specified.")
 	return editEventCmd
 }
 

--- a/foxglove/cmd/events_test.go
+++ b/foxglove/cmd/events_test.go
@@ -1,0 +1,224 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/foxglove/foxglove-cli/foxglove/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventsClient(t *testing.T) {
+	ctx := context.Background()
+	sv, err := api.NewMockServer(ctx)
+	require.NoError(t, err)
+	client := api.NewMockAuthedClient(t, sv.BaseURL())
+
+	created, err := client.CreateEvent(api.CreateEventRequest{
+		DeviceID:    "test-device",
+		Start:       "2023-04-19T13:26:37Z",
+		End:         "2023-04-19T13:26:38Z",
+		EventTypeID: "evtt_default",
+		Metadata:    map[string]string{"requires-labeling": "true"},
+		Properties:  map[string]interface{}{"severity": "high"},
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, created.ID)
+	assert.Equal(t, "test-device", created.Device.ID)
+	assert.Equal(t, "evtt_default", created.EventTypeID)
+	assert.Equal(t, map[string]string{"requires-labeling": "true"}, created.Metadata)
+
+	listed, err := client.Events(&api.EventsRequest{
+		DeviceID:    "test-device",
+		EventTypeID: "evtt_default",
+		EventID:     created.ID,
+		Query:       "requires-labeling:true",
+		QueryFields: "metadata,properties",
+	})
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	assert.Equal(t, created.ID, listed[0].ID)
+
+	got, err := client.GetEvent(created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, got.ID)
+
+	clearedType := ""
+	updated, err := client.UpdateEvent(created.ID, api.UpdateEventRequest{
+		Start:       "2023-04-19T13:26:40Z",
+		End:         "2023-04-19T13:26:41Z",
+		Metadata:    map[string]string{"note": "updated"},
+		EventTypeID: &clearedType,
+		Properties:  map[string]interface{}{"severity": nil},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, updated.ID)
+	assert.Equal(t, "2023-04-19T13:26:40Z", updated.Start)
+	assert.Equal(t, "", updated.EventTypeID)
+	assert.Equal(t, map[string]string{"note": "updated"}, updated.Metadata)
+
+	_, err = client.GetEvent("evt_missing")
+	assert.ErrorIs(t, err, api.ErrNotFound)
+
+	err = client.DeleteEvent(created.ID)
+	require.NoError(t, err)
+	listed, err = client.Events(&api.EventsRequest{EventID: created.ID})
+	require.NoError(t, err)
+	assert.Empty(t, listed)
+}
+
+func TestListEventsCommandSendsPublicQueryParams(t *testing.T) {
+	clientID := "custom-client"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/v1/events", r.URL.Path)
+		q := r.URL.Query()
+		assert.Equal(t, "dev_1", q.Get("deviceId"))
+		assert.Equal(t, "RobotA", q.Get("deviceName"))
+		assert.Equal(t, "prj_1", q.Get("projectId"))
+		assert.Equal(t, "evt_1", q.Get("eventId"))
+		assert.Equal(t, "evtt_1", q.Get("eventTypeId"))
+		assert.Equal(t, "2024-01-01T00:00:00Z", q.Get("start"))
+		assert.Equal(t, "2024-01-02T00:00:00Z", q.Get("end"))
+		assert.Equal(t, "2024-01-03T00:00:00Z", q.Get("createdAfter"))
+		assert.Equal(t, "2024-01-04T00:00:00Z", q.Get("updatedAfter"))
+		assert.Equal(t, "severity:high", q.Get("query"))
+		assert.Equal(t, "metadata,properties", q.Get("queryFields"))
+		assert.Equal(t, "createdAt", q.Get("sortBy"))
+		assert.Equal(t, "desc", q.Get("sortOrder"))
+		assert.Equal(t, "10", q.Get("limit"))
+		assert.Equal(t, "5", q.Get("offset"))
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	cmd := newListEventsCommand(&baseParams{
+		baseURL:   server.URL,
+		clientID:  &clientID,
+		token:     "custom-token",
+		userAgent: "foxglove-cli/test-version",
+	})
+	cmd.SetArgs([]string{
+		"--device-id", "dev_1",
+		"--device-name", "RobotA",
+		"--project-id", "prj_1",
+		"--event-id", "evt_1",
+		"--event-type-id", "evtt_1",
+		"--start", "2024-01-01T00:00:00Z",
+		"--end", "2024-01-02T00:00:00Z",
+		"--created-after", "2024-01-03T00:00:00Z",
+		"--updated-after", "2024-01-04T00:00:00Z",
+		"--query", "severity:high",
+		"--query-field", "metadata",
+		"--query-field", "properties",
+		"--sort-by", "createdAt",
+		"--sort-order", "desc",
+		"--limit", "10",
+		"--offset", "5",
+		"--format", "json",
+	})
+	assert.NoError(t, cmd.Execute())
+}
+
+func TestAddEventCommandSendsPublicBody(t *testing.T) {
+	clientID := "custom-client"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/v1/events", r.URL.Path)
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var req api.CreateEventRequest
+		require.NoError(t, json.Unmarshal(body, &req))
+		assert.Equal(t, "dev_1", req.DeviceID)
+		assert.Equal(t, "RobotA", req.DeviceName)
+		assert.Equal(t, "prj_1", req.ProjectID)
+		assert.Equal(t, "2024-01-01T00:00:00Z", req.Start)
+		assert.Equal(t, "2024-01-01T00:00:01Z", req.End)
+		assert.Equal(t, "evtt_1", req.EventTypeID)
+		assert.Equal(t, map[string]string{"k": "v"}, req.Metadata)
+		_, _ = w.Write([]byte(`{"id":"evt_created","start":"2024-01-01T00:00:00Z","end":"2024-01-01T00:00:01Z","metadata":{},"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}`))
+	}))
+	defer server.Close()
+
+	cmd := newAddEventCommand(&baseParams{
+		baseURL:   server.URL,
+		clientID:  &clientID,
+		token:     "custom-token",
+		userAgent: "foxglove-cli/test-version",
+	})
+	cmd.SetArgs([]string{
+		"--device-id", "dev_1",
+		"--device-name", "RobotA",
+		"--project-id", "prj_1",
+		"--start", "2024-01-01T00:00:00Z",
+		"--end", "2024-01-01T00:00:01Z",
+		"--event-type-id", "evtt_1",
+		"--metadata", "k:v",
+	})
+	assert.NoError(t, cmd.Execute())
+}
+
+func TestGetEditDeleteEventCommands(t *testing.T) {
+	clientID := "custom-client"
+	var patchBody api.UpdateEventRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/events/evt_1":
+			_, _ = w.Write([]byte(`{"id":"evt_1","start":"2024-01-01T00:00:00Z","end":"2024-01-01T00:00:01Z","device":{"id":"dev_1","name":"RobotA"},"metadata":{},"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}`))
+		case r.Method == http.MethodPatch && r.URL.Path == "/v1/events/evt_1":
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&patchBody))
+			_, _ = w.Write([]byte(`{"id":"evt_1","start":"2024-01-01T00:00:10Z","end":"2024-01-01T00:00:11Z","metadata":{"k":"v"},"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}`))
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/events/evt_1":
+			_, _ = w.Write([]byte(`{"id":"evt_1"}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	params := &baseParams{
+		baseURL:   server.URL,
+		clientID:  &clientID,
+		token:     "custom-token",
+		userAgent: "foxglove-cli/test-version",
+	}
+
+	getCmd := newGetEventCommand(params)
+	getCmd.SetArgs([]string{"evt_1", "--format", "json"})
+	assert.NoError(t, getCmd.Execute())
+
+	editCmd := newEditEventCommand(params)
+	editCmd.SetArgs([]string{"evt_1", "--start", "2024-01-01T00:00:10Z", "--end", "2024-01-01T00:00:11Z", "--metadata", "k:v", "--event-type-id", ""})
+	assert.NoError(t, editCmd.Execute())
+	assert.Equal(t, "2024-01-01T00:00:10Z", patchBody.Start)
+	assert.Equal(t, "2024-01-01T00:00:11Z", patchBody.End)
+	assert.Equal(t, map[string]string{"k": "v"}, patchBody.Metadata)
+	require.NotNil(t, patchBody.EventTypeID)
+	assert.Equal(t, "", *patchBody.EventTypeID)
+
+	deleteCmd := newDeleteEventCommand(params)
+	deleteCmd.SetArgs([]string{"evt_1"})
+	assert.NoError(t, deleteCmd.Execute())
+}
+
+func TestJoinQueryFields(t *testing.T) {
+	value, err := joinQueryFields([]string{"metadata", "properties"})
+	assert.NoError(t, err)
+	assert.Equal(t, "metadata,properties", value)
+
+	_, err = joinQueryFields([]string{"nope"})
+	assert.EqualError(t, err, `invalid --query-field value "nope": must be "metadata" or "properties"`)
+}
+
+func TestParseMetadataPairs(t *testing.T) {
+	metadata, err := parseMetadataPairs([]string{"a:b", "c:d:e"})
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"a": "b", "c": "d:e"}, metadata)
+
+	_, err = parseMetadataPairs([]string{"novalue"})
+	assert.Error(t, err)
+}

--- a/foxglove/cmd/events_test.go
+++ b/foxglove/cmd/events_test.go
@@ -24,21 +24,20 @@ func TestEventsClient(t *testing.T) {
 		Start:       "2023-04-19T13:26:37Z",
 		End:         "2023-04-19T13:26:38Z",
 		EventTypeID: "evtt_default",
-		Metadata:    map[string]string{"requires-labeling": "true"},
 		Properties:  map[string]interface{}{"severity": "high"},
 	})
 	require.NoError(t, err)
 	assert.NotEmpty(t, created.ID)
 	assert.Equal(t, "test-device", created.Device.ID)
 	assert.Equal(t, "evtt_default", created.EventTypeID)
-	assert.Equal(t, map[string]string{"requires-labeling": "true"}, created.Metadata)
+	assert.Empty(t, created.Metadata)
 
 	listed, err := client.Events(&api.EventsRequest{
 		DeviceID:    "test-device",
 		EventTypeID: "evtt_default",
 		EventID:     created.ID,
-		Query:       "requires-labeling:true",
-		QueryFields: "metadata,properties",
+		Query:       "severity:high",
+		QueryFields: "properties",
 	})
 	require.NoError(t, err)
 	require.Len(t, listed, 1)
@@ -49,10 +48,11 @@ func TestEventsClient(t *testing.T) {
 	assert.Equal(t, created.ID, got.ID)
 
 	clearedType := ""
+	metadata := map[string]string{"note": "updated"}
 	updated, err := client.UpdateEvent(created.ID, api.UpdateEventRequest{
 		Start:       "2023-04-19T13:26:40Z",
 		End:         "2023-04-19T13:26:41Z",
-		Metadata:    map[string]string{"note": "updated"},
+		Metadata:    &metadata,
 		EventTypeID: &clearedType,
 		Properties:  map[string]interface{}{"severity": nil},
 	})
@@ -140,7 +140,7 @@ func TestAddEventCommandSendsPublicBody(t *testing.T) {
 		assert.Equal(t, "2024-01-01T00:00:00Z", req.Start)
 		assert.Equal(t, "2024-01-01T00:00:01Z", req.End)
 		assert.Equal(t, "evtt_1", req.EventTypeID)
-		assert.Equal(t, map[string]string{"k": "v"}, req.Metadata)
+		assert.Empty(t, req.Metadata)
 		_, _ = w.Write([]byte(`{"id":"evt_created","start":"2024-01-01T00:00:00Z","end":"2024-01-01T00:00:01Z","metadata":{},"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}`))
 	}))
 	defer server.Close()
@@ -158,7 +158,6 @@ func TestAddEventCommandSendsPublicBody(t *testing.T) {
 		"--start", "2024-01-01T00:00:00Z",
 		"--end", "2024-01-01T00:00:01Z",
 		"--event-type-id", "evtt_1",
-		"--metadata", "k:v",
 	})
 	assert.NoError(t, cmd.Execute())
 }
@@ -171,6 +170,7 @@ func TestGetEditDeleteEventCommands(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/events/evt_1":
 			_, _ = w.Write([]byte(`{"id":"evt_1","start":"2024-01-01T00:00:00Z","end":"2024-01-01T00:00:01Z","device":{"id":"dev_1","name":"RobotA"},"metadata":{},"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}`))
 		case r.Method == http.MethodPatch && r.URL.Path == "/v1/events/evt_1":
+			patchBody = api.UpdateEventRequest{}
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&patchBody))
 			_, _ = w.Write([]byte(`{"id":"evt_1","start":"2024-01-01T00:00:10Z","end":"2024-01-01T00:00:11Z","metadata":{"k":"v"},"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}`))
 		case r.Method == http.MethodDelete && r.URL.Path == "/v1/events/evt_1":
@@ -192,13 +192,26 @@ func TestGetEditDeleteEventCommands(t *testing.T) {
 	assert.NoError(t, getCmd.Execute())
 
 	editCmd := newEditEventCommand(params)
-	editCmd.SetArgs([]string{"evt_1", "--start", "2024-01-01T00:00:10Z", "--end", "2024-01-01T00:00:11Z", "--metadata", "k:v", "--event-type-id", ""})
+	editCmd.SetArgs([]string{"evt_1", "--start", "2024-01-01T00:00:10Z", "--end", "2024-01-01T00:00:11Z", "--metadata", "k:v", "--event-type-id", "", "--remove-property", "severity"})
 	assert.NoError(t, editCmd.Execute())
 	assert.Equal(t, "2024-01-01T00:00:10Z", patchBody.Start)
 	assert.Equal(t, "2024-01-01T00:00:11Z", patchBody.End)
-	assert.Equal(t, map[string]string{"k": "v"}, patchBody.Metadata)
+	require.NotNil(t, patchBody.Metadata)
+	assert.Equal(t, map[string]string{"k": "v"}, *patchBody.Metadata)
 	require.NotNil(t, patchBody.EventTypeID)
 	assert.Equal(t, "", *patchBody.EventTypeID)
+	assert.Contains(t, patchBody.Properties, "severity")
+	assert.Nil(t, patchBody.Properties["severity"])
+
+	clearMetadataCmd := newEditEventCommand(params)
+	clearMetadataCmd.SetArgs([]string{"evt_1", "--clear-metadata"})
+	assert.NoError(t, clearMetadataCmd.Execute())
+	require.NotNil(t, patchBody.Metadata)
+	assert.Empty(t, *patchBody.Metadata)
+
+	invalidMetadataCmd := newEditEventCommand(params)
+	invalidMetadataCmd.SetArgs([]string{"evt_1", "--metadata", "k:v", "--clear-metadata"})
+	assert.EqualError(t, invalidMetadataCmd.Execute(), "--metadata and --clear-metadata cannot be used together")
 
 	deleteCmd := newDeleteEventCommand(params)
 	deleteCmd.SetArgs([]string{"evt_1"})
@@ -221,4 +234,29 @@ func TestParseMetadataPairs(t *testing.T) {
 
 	_, err = parseMetadataPairs([]string{"novalue"})
 	assert.Error(t, err)
+}
+
+func TestParseEventPropertiesToRemove(t *testing.T) {
+	properties, err := parseEventProperties(nil, nil, []string{"severity", "note"})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"severity": nil,
+		"note":     nil,
+	}, properties)
+
+	_, err = parseEventProperties(nil, nil, []string{""})
+	assert.EqualError(t, err, "custom property key to remove cannot be empty")
+}
+
+func TestValidateCreateEventData(t *testing.T) {
+	assert.EqualError(t,
+		validateCreateEventData("evtt_1", []string{"note:value"}, nil),
+		"--metadata cannot be used with --event-type-id",
+	)
+	assert.EqualError(t,
+		validateCreateEventData("", nil, []string{"severity:high"}),
+		"--event-type-id is required when using --property",
+	)
+	assert.NoError(t, validateCreateEventData("", []string{"note:value"}, nil))
+	assert.NoError(t, validateCreateEventData("evtt_1", nil, []string{"severity:high"}))
 }

--- a/foxglove/cmd/events_test.go
+++ b/foxglove/cmd/events_test.go
@@ -245,7 +245,7 @@ func TestParseEventPropertiesToRemove(t *testing.T) {
 	}, properties)
 
 	_, err = parseEventProperties(nil, nil, []string{""})
-	assert.EqualError(t, err, "custom property key to remove cannot be empty")
+	assert.EqualError(t, err, "property key to remove cannot be empty")
 }
 
 func TestValidateCreateEventData(t *testing.T) {
@@ -254,9 +254,10 @@ func TestValidateCreateEventData(t *testing.T) {
 		"--metadata cannot be used with --event-type-id",
 	)
 	assert.EqualError(t,
-		validateCreateEventData("", nil, []string{"severity:high"}),
-		"--event-type-id is required when using --property",
+		validateCreateEventData("", []string{"note:value"}, []string{"severity:high"}),
+		"--metadata cannot be used with --property",
 	)
 	assert.NoError(t, validateCreateEventData("", []string{"note:value"}, nil))
+	assert.NoError(t, validateCreateEventData("", nil, []string{"severity:high"}))
 	assert.NoError(t, validateCreateEventData("evtt_1", nil, []string{"severity:high"}))
 }

--- a/foxglove/cmd/root.go
+++ b/foxglove/cmd/root.go
@@ -157,7 +157,7 @@ func Execute(version string) {
 	}
 	eventTypesCmd := &cobra.Command{
 		Use:   "event-types",
-		Short: "List event types",
+		Short: "List and manage event types",
 	}
 	pendingImportsCmd := &cobra.Command{
 		Use:   "pending-imports",
@@ -247,8 +247,20 @@ func Execute(version string) {
 		newSessionRecordingsCommand(params),
 		newDeleteSessionCommand(params),
 	)
-	eventsCmd.AddCommand(newListEventsCommand(params), newAddEventCommand(params))
-	eventTypesCmd.AddCommand(newListEventTypesCommand(params))
+	eventsCmd.AddCommand(
+		newListEventsCommand(params),
+		newAddEventCommand(params),
+		newGetEventCommand(params),
+		newEditEventCommand(params),
+		newDeleteEventCommand(params),
+	)
+	eventTypesCmd.AddCommand(
+		newListEventTypesCommand(params),
+		newAddEventTypeCommand(params),
+		newGetEventTypeCommand(params),
+		newEditEventTypeCommand(params),
+		newDeleteEventTypeCommand(params),
+	)
 	extensionsCmd.AddCommand(newListExtensionsCommand(params))
 	extensionsCmd.AddCommand(newPublishExtensionCommand(params))
 	extensionsCmd.AddCommand(newUnpublishExtensionCommand(params))

--- a/foxglove/cmd/utils.go
+++ b/foxglove/cmd/utils.go
@@ -124,6 +124,22 @@ func renderJSON[RecordType api.Record](w io.Writer, records []RecordType) error 
 	return encoder.Encode(records)
 }
 
+func renderRecord[RecordType api.Record](w io.Writer, record RecordType, format string) error {
+	switch format {
+	case "table":
+		tw.PrintTable(w, record.Headers(), [][]string{record.Fields()})
+	case "json":
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "    ")
+		return encoder.Encode(record)
+	case "csv":
+		return renderCSV(w, []RecordType{record})
+	default:
+		return fmt.Errorf("unsupported format %s", format)
+	}
+	return nil
+}
+
 func renderCSV[RecordType api.Record](w io.Writer, records []RecordType) error {
 	writer := csv.NewWriter(w)
 	err := writer.Write(records[0].Headers())

--- a/foxglove/cmd/utils.go
+++ b/foxglove/cmd/utils.go
@@ -262,7 +262,7 @@ func maybeConvertToRFC3339(timestamp string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return parsed.Format(time.RFC3339), nil
+	return parsed.Format(time.RFC3339Nano), nil
 }
 
 func TokenIsApiKey(token string) bool {

--- a/foxglove/cmd/utils_test.go
+++ b/foxglove/cmd/utils_test.go
@@ -74,6 +74,17 @@ func TestRenderJSON(t *testing.T) {
 			"\n", ""))
 }
 
+func TestRenderRecord(t *testing.T) {
+	record := TestRecord{A: "a", B: "b"}
+	buf := &bytes.Buffer{}
+	err := renderRecord(buf, record, "json")
+	assert.Nil(t, err)
+	assert.Equal(t, `{"a":"a","b":"b"}`,
+		strings.ReplaceAll(
+			strings.ReplaceAll(strings.TrimSpace(buf.String()), " ", ""),
+			"\n", ""))
+}
+
 func TestRenderList(t *testing.T) {
 	records := []TestRecord{
 		{A: "a", B: "b"},

--- a/foxglove/cmd/utils_test.go
+++ b/foxglove/cmd/utils_test.go
@@ -130,6 +130,12 @@ func TestMaybeConvertToRFC3339(t *testing.T) {
 			nil,
 		},
 		{
+			"preserves subsecond precision",
+			"2021-01-01T00:00:00.123456789Z",
+			"2021-01-01T00:00:00.123456789Z",
+			nil,
+		},
+		{
 			"accepts ISO8601",
 			"2021-01-01",
 			"2021-01-01T00:00:00Z",

--- a/foxglove/util/custom_properties.go
+++ b/foxglove/util/custom_properties.go
@@ -112,10 +112,14 @@ func fetchAvailableProperties(client *api.FoxgloveClient, resourceType string) (
 
 	properties := make(map[string]PropertyDefinition)
 	for _, prop := range propertiesResp {
+		enumValues := prop.EnumValues
+		if enumValues == nil {
+			enumValues = prop.Values
+		}
 		properties[prop.Key] = PropertyDefinition{
 			Key:        prop.Key,
 			ValueType:  prop.ValueType,
-			EnumValues: valueSet(prop.Values),
+			EnumValues: valueSet(enumValues),
 		}
 	}
 

--- a/foxglove/util/custom_properties.go
+++ b/foxglove/util/custom_properties.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/foxglove/foxglove-cli/foxglove/api"
 )
@@ -18,11 +19,21 @@ type PropertyDefinition struct {
 // Validate CLI properties input & convert to args for a device request.
 // This requires downloading the available properties for the org.
 func DeviceProperties(propertyPairs []string, client *api.FoxgloveClient) (map[string]interface{}, error) {
+	return ResourceProperties(propertyPairs, client, "device")
+}
+
+// EventProperties validates CLI properties input for event custom properties.
+func EventProperties(propertyPairs []string, client *api.FoxgloveClient) (map[string]interface{}, error) {
+	return ResourceProperties(propertyPairs, client, "event")
+}
+
+// ResourceProperties validates CLI properties input for a custom-property resource type.
+func ResourceProperties(propertyPairs []string, client *api.FoxgloveClient, resourceType string) (map[string]interface{}, error) {
 	if len(propertyPairs) == 0 {
 		return nil, nil
 	}
 
-	propertyMap, err := fetchAvailableProperties(client)
+	propertyMap, err := fetchAvailableProperties(client, resourceType)
 	if err != nil {
 		return nil, fmt.Errorf("%s", err)
 	}
@@ -39,36 +50,61 @@ func DeviceProperties(propertyPairs []string, client *api.FoxgloveClient) (map[s
 			return nil, fmt.Errorf("unknown key: %s", key)
 		}
 
-		switch property.ValueType {
-		case "string":
-			properties[key] = val
-		case "number":
-			properties[key], err = strconv.ParseFloat(val, 64)
-			if err != nil {
-				return nil, fmt.Errorf("invalid value for number: %s", val)
-			}
-		case "enum":
-			_, hasVal := property.EnumValues[val]
-			if !hasVal {
-				return nil, fmt.Errorf("invalid enum value: %s", val)
-			}
-			properties[key] = val
-		case "boolean":
-			properties[key], err = strconv.ParseBool(val)
-			if err != nil {
-				return nil, fmt.Errorf("invalid value for boolean: %s", val)
-			}
-		default:
-			return nil, fmt.Errorf("unsupported type: %s", property.ValueType)
+		parsed, err := parsePropertyValue(property, val)
+		if err != nil {
+			return nil, err
 		}
+		properties[key] = parsed
 	}
 	return properties, nil
 }
 
-// Download device custom properties and convert to a lookup map
-func fetchAvailableProperties(client *api.FoxgloveClient) (OrgCustomProperties, error) {
+func parsePropertyValue(property PropertyDefinition, val string) (interface{}, error) {
+	switch property.ValueType {
+	case "string", "multiline-string":
+		return val, nil
+	case "number":
+		parsed, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for number: %s", val)
+		}
+		return parsed, nil
+	case "enum":
+		_, hasVal := property.EnumValues[val]
+		if !hasVal {
+			return nil, fmt.Errorf("invalid enum value: %s", val)
+		}
+		return val, nil
+	case "multi-enum":
+		parts := strings.Split(val, ",")
+		values := make([]string, 0, len(parts))
+		for _, part := range parts {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			_, hasVal := property.EnumValues[part]
+			if !hasVal {
+				return nil, fmt.Errorf("invalid enum value: %s", part)
+			}
+			values = append(values, part)
+		}
+		return values, nil
+	case "boolean":
+		parsed, err := strconv.ParseBool(val)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for boolean: %s", val)
+		}
+		return parsed, nil
+	default:
+		return nil, fmt.Errorf("unsupported type: %s", property.ValueType)
+	}
+}
+
+// Download custom properties for a resource type and convert to a lookup map
+func fetchAvailableProperties(client *api.FoxgloveClient, resourceType string) (OrgCustomProperties, error) {
 	propertiesResp, err := client.DeviceCustomProperties(api.CustomPropertiesRequest{
-		ResourceType: "device",
+		ResourceType: resourceType,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to load custom properties: %w", err)

--- a/foxglove/util/custom_properties_test.go
+++ b/foxglove/util/custom_properties_test.go
@@ -65,6 +65,28 @@ func TestDeviceProperties(t *testing.T) {
 	})
 }
 
+func TestEventProperties(t *testing.T) {
+	ctx := context.Background()
+	sv, err := api.NewMockServer(ctx)
+	assert.Nil(t, err)
+	client := newAuthedClient(t, sv.BaseURL())
+
+	t.Run("converts event custom property values", func(t *testing.T) {
+		properties, err := EventProperties([]string{"severity:high", "status:open", "tags:a,b"}, client)
+		assert.Nil(t, err)
+		assert.Equal(t, map[string]interface{}{
+			"severity": "high",
+			"status":   "open",
+			"tags":     []string{"a", "b"},
+		}, properties)
+	})
+
+	t.Run("rejects unknown event keys", func(t *testing.T) {
+		_, err := EventProperties([]string{"str:bar"}, client)
+		assert.Equal(t, fmt.Errorf("unknown key: str"), err)
+	})
+}
+
 func newAuthedClient(t *testing.T, baseUrl string) *api.FoxgloveClient {
 	client := api.NewRemoteFoxgloveClient(
 		baseUrl,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog

The CLI now supports all public `/v1/events` and `/v1/event-types` methods: list, get, create, update, and delete, including the documented query and body parameters.

### Docs

README events section now includes get, edit, and delete. A new event-types section shows add, list, get, edit, and delete.

### Description

The CLI already had `events list`, `events add`, and `event-types list`. The public API also has get, update, and delete for both resources, plus more list and create parameters.

This change adds those commands and aligns request fields with the public OpenAPI spec:

- Events list: `deviceId`, `deviceName`, `projectId`, `eventId`, `createdAfter`, `updatedAfter`, and comma-separated `queryFields`
- Event create: `deviceName`, `projectId`, and typed `properties`
- Event update and delete, plus event get
- Event-type create, get, update, and delete, with `customProperties` as `{id, required}`

Event custom property flags use the same colon-separated `key:value` pattern as device properties. Event-type `--custom-property` accepts a custom property ID, or `ID:true` / `ID:false` for the required flag.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bef9f7c7-fc60-45c9-a928-9ebb143e3237?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bef9f7c7-fc60-45c9-a928-9ebb143e3237&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

