### PR TITLE
allow updating an existing session key

### DIFF
--- a/foxglove/api/api.go
+++ b/foxglove/api/api.go
@@ -646,7 +646,9 @@ type SessionRecordingsResponse struct {
 	RecordingIDs []string `json:"recordingIds"`
 }
 
-type PatchSessionRecordingsRequest struct {
+// PatchSessionRequest is the body for PATCH /v1/sessions/{keyOrId}.
+type PatchSessionRequest struct {
+	Key                string   `json:"key,omitempty"`
 	AddRecordingIDs    []string `json:"addRecordingIds,omitempty"`
 	RemoveRecordingIDs []string `json:"removeRecordingIds,omitempty"`
 }

--- a/foxglove/api/client.go
+++ b/foxglove/api/client.go
@@ -418,8 +418,9 @@ func (c *FoxgloveClient) ListSessionRecordings(keyOrID string, projectID string)
 	return SessionRecordingsResponse{RecordingIDs: ids}, nil
 }
 
-// PatchSessionRecordings adds or removes recordings in a session via PATCH /sessions/{keyOrId}.
-func (c *FoxgloveClient) PatchSessionRecordings(keyOrID string, projectID string, req PatchSessionRecordingsRequest) (UpdateSessionResponse, error) {
+// PatchSession updates a session through PATCH /v1/sessions/{keyOrId}.
+// You can change the key or add or remove recordings.
+func (c *FoxgloveClient) PatchSession(keyOrID string, projectID string, req PatchSessionRequest) (UpdateSessionResponse, error) {
 	path, err := url.JoinPath("/v1/sessions", keyOrID)
 	if err != nil {
 		return UpdateSessionResponse{}, err
@@ -430,14 +431,14 @@ func (c *FoxgloveClient) PatchSessionRecordings(keyOrID string, projectID string
 }
 
 func (c *FoxgloveClient) AddRecordingToSession(keyOrID string, projectID string, recordingID string) error {
-	_, err := c.PatchSessionRecordings(keyOrID, projectID, PatchSessionRecordingsRequest{
+	_, err := c.PatchSession(keyOrID, projectID, PatchSessionRequest{
 		AddRecordingIDs: []string{recordingID},
 	})
 	return err
 }
 
 func (c *FoxgloveClient) RemoveRecordingFromSession(keyOrID string, projectID string, recordingID string) error {
-	_, err := c.PatchSessionRecordings(keyOrID, projectID, PatchSessionRecordingsRequest{
+	_, err := c.PatchSession(keyOrID, projectID, PatchSessionRequest{
 		RemoveRecordingIDs: []string{recordingID},
 	})
 	return err

--- a/foxglove/api/mock_service.go
+++ b/foxglove/api/mock_service.go
@@ -304,7 +304,7 @@ func (s *MockFoxgloveServer) createSession(w http.ResponseWriter, r *http.Reques
 
 func (s *MockFoxgloveServer) patchSession(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
-	req := PatchSessionRecordingsRequest{}
+	req := PatchSessionRequest{}
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
@@ -327,14 +327,17 @@ func (s *MockFoxgloveServer) patchSession(w http.ResponseWriter, r *http.Request
 					removeSet[rid] = true
 				}
 				newRecs := make([]SessionRecordingSummary, 0, len(recs))
-				for _, r := range recs {
-					if !removeSet[r.ID] {
-						newRecs = append(newRecs, r)
+				for _, rec := range recs {
+					if !removeSet[rec.ID] {
+						newRecs = append(newRecs, rec)
 					}
 				}
 				recs = newRecs
 			}
 			s.registeredSessions[i].Recordings = recs
+			if req.Key != "" {
+				s.registeredSessions[i].Key = req.Key
+			}
 			s.registeredSessions[i].UpdatedAt = time.Now()
 			sess := &s.registeredSessions[i]
 			_ = json.NewEncoder(w).Encode(UpdateSessionResponse{

--- a/foxglove/cmd/root.go
+++ b/foxglove/cmd/root.go
@@ -244,6 +244,7 @@ func Execute(version string) {
 		newListSessionsCommand(params),
 		newGetSessionCommand(params),
 		newAddSessionCommand(params),
+		newEditSessionCommand(params),
 		newSessionRecordingsCommand(params),
 		newDeleteSessionCommand(params),
 	)

--- a/foxglove/cmd/sessions.go
+++ b/foxglove/cmd/sessions.go
@@ -142,6 +142,44 @@ func newAddSessionCommand(params *baseParams) *cobra.Command {
 	return addSessionCmd
 }
 
+func newEditSessionCommand(params *baseParams) *cobra.Command {
+	var key string
+	var projectID string
+	editSessionCmd := &cobra.Command{
+		Use:   "edit [session-id-or-key]",
+		Short: "Edit a session",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if key == "" {
+				dief("Nothing to update. Provide --key.")
+			}
+			client := api.NewRemoteFoxgloveClient(
+				params.baseURL, *params.clientID,
+				params.token,
+				params.userAgent,
+			)
+			keyOrID := args[0]
+			resp, err := client.PatchSession(keyOrID, projectID, api.PatchSessionRequest{
+				Key: key,
+			})
+			if err != nil {
+				if err == api.ErrForbidden {
+					dief("Not authenticated. Run foxglove auth login.")
+				}
+				dief("Failed to edit session: %s", err)
+			}
+			fmt.Fprintf(os.Stderr, "Session updated: %s\n", resp.ID)
+			if resp.Key != "" {
+				fmt.Fprintf(os.Stderr, "Session key: %s\n", resp.Key)
+			}
+		},
+	}
+	editSessionCmd.InheritedFlags()
+	editSessionCmd.PersistentFlags().StringVarP(&key, "key", "", "", "New key for the session")
+	editSessionCmd.PersistentFlags().StringVarP(&projectID, "project-id", "", viper.GetString("default_project_id"), "Project ID (required when session-id-or-key is a session key)")
+	return editSessionCmd
+}
+
 func newSessionRecordingsCommand(params *baseParams) *cobra.Command {
 	recordingsCmd := &cobra.Command{
 		Use:   "recordings",

--- a/foxglove/cmd/sessions_test.go
+++ b/foxglove/cmd/sessions_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/foxglove/foxglove-cli/foxglove/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEditSessionCommand(t *testing.T) {
+	ctx := context.Background()
+	sv, err := api.NewMockServer(ctx)
+	assert.Nil(t, err)
+
+	t.Run("updates a session key", func(t *testing.T) {
+		client := api.NewMockAuthedClient(t, sv.BaseURL())
+		created, err := client.CreateSession(api.CreateSessionRequest{
+			Name:      "test-session",
+			ProjectID: "prj_1234abcd",
+			DeviceID:  "dev_1234abcd",
+		})
+		assert.Nil(t, err)
+		assert.NotEmpty(t, created.Key)
+
+		updated, err := client.PatchSession(created.ID, created.ProjectID, api.PatchSessionRequest{
+			Key: "new-session-key",
+		})
+		assert.Nil(t, err)
+		assert.Equal(t, created.ID, updated.ID)
+		assert.Equal(t, "new-session-key", updated.Key)
+
+		fetched, err := client.GetSession("new-session-key", created.ProjectID)
+		assert.Nil(t, err)
+		assert.Equal(t, created.ID, fetched.ID)
+		assert.Equal(t, "new-session-key", fetched.Key)
+
+		_, err = client.GetSession(created.Key, created.ProjectID)
+		assert.ErrorIs(t, err, api.ErrNotFound)
+
+		fetchedByID, err := client.GetSession(created.ID, created.ProjectID)
+		assert.Nil(t, err)
+		assert.Equal(t, "new-session-key", fetchedByID.Key)
+	})
+
+	t.Run("adds recordings without changing the key", func(t *testing.T) {
+		client := api.NewMockAuthedClient(t, sv.BaseURL())
+		created, err := client.CreateSession(api.CreateSessionRequest{
+			Name:      "recordings-session",
+			ProjectID: "prj_1234abcd",
+			DeviceID:  "dev_1234abcd",
+		})
+		assert.Nil(t, err)
+
+		updated, err := client.PatchSession(created.ID, created.ProjectID, api.PatchSessionRequest{
+			AddRecordingIDs: []string{"rec_1"},
+		})
+		assert.Nil(t, err)
+		assert.Equal(t, created.Key, updated.Key)
+
+		fetched, err := client.GetSession(created.ID, created.ProjectID)
+		assert.Nil(t, err)
+		assert.Equal(t, created.Key, fetched.Key)
+		assert.Equal(t, []api.SessionRecordingSummary{{ID: "rec_1"}}, fetched.Recordings)
+	})
+}


### PR DESCRIPTION
## Summary

Allows updating a session `key` for an existing session.

Example:

```
foxglove sessions edit rs_abc123 --key new-key
```